### PR TITLE
Security: Fix 5 critical/high/medium vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,7 +1862,7 @@
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "agentlaunch-sdk": "^0.2.4",
+        "agentlaunch-sdk": "^0.2.6",
         "agentlaunch-templates": "^0.4.0",
         "commander": "^12.0.0",
         "ethers": "^6.0.0"
@@ -1884,7 +1884,7 @@
       "version": "2.1.7",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "agentlaunch-sdk": "^0.2.4",
+        "agentlaunch-sdk": "^0.2.6",
         "agentlaunch-templates": "^0.4.0",
         "ethers": "^6.0.0"
       },

--- a/packages/cli/src/commands/tokenize.ts
+++ b/packages/cli/src/commands/tokenize.ts
@@ -201,6 +201,36 @@ export function registerTokenizeCommand(program: Command): void {
           process.exit(1);
         }
 
+        // Security: Validate image URL if provided (SSRF prevention)
+        if (options.image) {
+          try {
+            const parsedUrl = new URL(options.image);
+            if (parsedUrl.protocol !== 'https:') {
+              if (isJson) {
+                console.log(
+                  JSON.stringify({
+                    error: '--image URL must use HTTPS protocol',
+                  }),
+                );
+              } else {
+                console.error('Error: --image URL must use HTTPS protocol');
+              }
+              process.exit(1);
+            }
+          } catch {
+            if (isJson) {
+              console.log(
+                JSON.stringify({
+                  error: '--image must be a valid URL',
+                }),
+              );
+            } else {
+              console.error('Error: --image must be a valid URL');
+            }
+            process.exit(1);
+          }
+        }
+
         const body: TokenizeBody = {
           agentAddress: options.agent,
           name: options.name,

--- a/packages/mcp/src/tools/agentverse.ts
+++ b/packages/mcp/src/tools/agentverse.ts
@@ -1,6 +1,20 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { deployAgent, updateAgent, buildOptimizationChecklist } from 'agentlaunch-sdk';
 import type { AgentverseDeployResult, AgentMetadata, OptimizationCheckItem } from 'agentlaunch-sdk';
+
+/**
+ * Validates that a file path is within the current working directory.
+ * Prevents path traversal attacks (e.g., reading /etc/passwd via ../../).
+ */
+function validatePathWithinCwd(filePath: string, paramName: string): string {
+  const resolved = path.resolve(filePath);
+  const cwd = path.resolve(process.cwd());
+  if (!resolved.startsWith(cwd + path.sep) && resolved !== cwd) {
+    throw new Error(`${paramName} must be within the current working directory`);
+  }
+  return resolved;
+}
 
 // ---------------------------------------------------------------------------
 // Return type
@@ -34,12 +48,15 @@ export async function deployToAgentverse(args: {
   readme?: string;
   shortDescription?: string;
 }): Promise<DeployToAgentverseResult> {
+  // Security: Validate file path is within current working directory
+  const safeAgentFile = validatePathWithinCwd(args.agentFile, 'agentFile');
+
   // Read agent source code
-  if (!fs.existsSync(args.agentFile)) {
+  if (!fs.existsSync(safeAgentFile)) {
     throw new Error(`Agent file not found: ${args.agentFile}`);
   }
 
-  const sourceCode = fs.readFileSync(args.agentFile, 'utf8');
+  const sourceCode = fs.readFileSync(safeAgentFile, 'utf8');
   if (!sourceCode.trim()) {
     throw new Error(`Agent file is empty: ${args.agentFile}`);
   }

--- a/packages/mcp/src/tools/comments.ts
+++ b/packages/mcp/src/tools/comments.ts
@@ -3,6 +3,19 @@ import type { Comment } from 'agentlaunch-sdk';
 
 const client = new AgentLaunchClient();
 
+/** Regex to validate Ethereum addresses: 0x followed by exactly 40 hex characters */
+const ETH_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Validates that an address is a valid Ethereum address format.
+ * Prevents URL injection via addresses containing special characters.
+ */
+function validateEthAddress(address: string): void {
+  if (!ETH_ADDRESS_REGEX.test(address)) {
+    throw new Error(`Invalid token address format: ${address}. Expected 0x followed by 40 hex characters.`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tool implementations
 // ---------------------------------------------------------------------------
@@ -19,6 +32,9 @@ export async function getComments(args: {
   if (!args.address || !args.address.trim()) {
     throw new Error('address is required');
   }
+
+  // Security: Validate address format
+  validateEthAddress(args.address);
 
   return client.get<Comment[]>(`/comments/${encodeURIComponent(args.address)}`);
 }
@@ -39,6 +55,9 @@ export async function postComment(args: {
   if (!args.message || !args.message.trim()) {
     throw new Error('message is required');
   }
+
+  // Security: Validate address format
+  validateEthAddress(args.address);
 
   return client.post<unknown>(`/comments/${encodeURIComponent(args.address)}`, {
     message: args.message,

--- a/packages/mcp/src/tools/handoff.ts
+++ b/packages/mcp/src/tools/handoff.ts
@@ -4,6 +4,19 @@ import type { Token } from 'agentlaunch-sdk';
 const client = new AgentLaunchClient();
 const FRONTEND_BASE_URL = getFrontendUrl();
 
+/** Regex to validate Ethereum addresses: 0x followed by exactly 40 hex characters */
+const ETH_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Validates that an address is a valid Ethereum address format.
+ * Prevents URL injection via addresses containing special characters like ? or #.
+ */
+function validateEthAddress(address: string): void {
+  if (!ETH_ADDRESS_REGEX.test(address)) {
+    throw new Error(`Invalid token address format: ${address}. Expected 0x followed by 40 hex characters.`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Return types
 // ---------------------------------------------------------------------------
@@ -192,6 +205,9 @@ export async function getTradeLink(args: {
   action: 'buy' | 'sell';
   amount?: string;
 }): Promise<TradeLink> {
+  // Security: Validate address format to prevent URL injection
+  validateEthAddress(args.address);
+
   const params = new URLSearchParams();
   params.set('action', args.action);
   if (args.amount) {

--- a/packages/mcp/src/tools/scaffold.ts
+++ b/packages/mcp/src/tools/scaffold.ts
@@ -2,6 +2,19 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { generateFromTemplate } from 'agentlaunch-templates';
 
+/**
+ * Validates that a directory path is within the current working directory.
+ * Prevents path traversal attacks (e.g., writing to /etc/ via ../../).
+ */
+function validatePathWithinCwd(dirPath: string, paramName: string): string {
+  const resolved = path.resolve(dirPath);
+  const cwd = path.resolve(process.cwd());
+  if (!resolved.startsWith(cwd + path.sep) && resolved !== cwd) {
+    throw new Error(`${paramName} must be within the current working directory`);
+  }
+  return resolved;
+}
+
 // ---------------------------------------------------------------------------
 // Type mapping: MCP agent types -> template names
 // ---------------------------------------------------------------------------
@@ -44,10 +57,9 @@ export async function scaffoldAgent(args: {
   const agentType = args.type ?? 'research';
   const templateName = TYPE_TO_TEMPLATE[agentType] ?? 'custom';
 
-  // Resolve output directory
-  const outputDir = path.resolve(
-    args.outputDir ?? path.join(process.cwd(), args.name.toLowerCase().replace(/\s+/g, '-')),
-  );
+  // Resolve output directory with security validation
+  const rawOutputDir = args.outputDir ?? path.join(process.cwd(), args.name.toLowerCase().replace(/\s+/g, '-'));
+  const outputDir = validatePathWithinCwd(rawOutputDir, 'outputDir');
 
   // Create base directory and .claude/ subdirectory
   fs.mkdirSync(outputDir, { recursive: true });
@@ -143,10 +155,9 @@ export async function scaffoldSwarm(args: {
 }): Promise<ScaffoldSwarmResult> {
   const presetName = args.preset ?? 'custom';
 
-  // Resolve output directory
-  const outputDir = path.resolve(
-    args.outputDir ?? path.join(process.cwd(), args.name.toLowerCase().replace(/\s+/g, '-')),
-  );
+  // Resolve output directory with security validation
+  const rawOutputDir = args.outputDir ?? path.join(process.cwd(), args.name.toLowerCase().replace(/\s+/g, '-'));
+  const outputDir = validatePathWithinCwd(rawOutputDir, 'outputDir');
 
   // Create base directory and .claude/ subdirectory
   fs.mkdirSync(outputDir, { recursive: true });

--- a/packages/mcp/src/tools/tokenize.ts
+++ b/packages/mcp/src/tools/tokenize.ts
@@ -4,6 +4,18 @@ import { generateFromTemplate } from 'agentlaunch-templates';
 const client = new AgentLaunchClient();
 const FRONTEND_BASE_URL = getFrontendUrl();
 
+/** Regex to validate Ethereum addresses: 0x followed by exactly 40 hex characters */
+const ETH_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Validates that an address is a valid Ethereum address format.
+ * Prevents URL injection via addresses containing special characters like ? or #.
+ * Returns true if valid, false otherwise (does not throw).
+ */
+function isValidEthAddress(address: string | undefined | null): address is string {
+  return !!address && ETH_ADDRESS_REGEX.test(address);
+}
+
 // ---------------------------------------------------------------------------
 // Type mapping: MCP template types -> template names
 // ---------------------------------------------------------------------------
@@ -179,8 +191,10 @@ export async function createAndTokenize(args: {
     nested.handoff_link ??
     `${FRONTEND_BASE_URL}/deploy/${tokenId}`;
 
+  // Security: Only use tokenAddress if it's a valid Ethereum address format
+  // This prevents URL injection via addresses containing special characters
   const tokenAddress = nested.address;
-  const tradeTarget = tokenAddress ?? String(tokenId);
+  const tradeTarget = isValidEthAddress(tokenAddress) ? tokenAddress : String(tokenId);
   const deployLink = `${FRONTEND_BASE_URL}/trade/${tradeTarget}?action=buy&amount=100`;
 
   return {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -154,9 +154,12 @@ export class AgentLaunchClient {
       const delayMs = 1000 * Math.pow(2, attempt);
       attempt++;
 
-      // Respect Retry-After header if the server sends one
+      // Respect Retry-After header if the server sends one, but cap at 30 seconds
+      // to prevent DoS via malicious Retry-After values
+      const MAX_RETRY_WAIT_MS = 30000;
       const retryAfter = response.headers.get('Retry-After');
-      const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : delayMs;
+      const requestedWaitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : delayMs;
+      const waitMs = Math.min(requestedWaitMs, MAX_RETRY_WAIT_MS);
 
       await sleep(waitMs);
 

--- a/packages/sdk/src/handoff.ts
+++ b/packages/sdk/src/handoff.ts
@@ -16,6 +16,19 @@
 import type { TradeLinkOptions, TradeAction } from './types.js';
 import { getFrontendUrl } from './urls.js';
 
+/** Regex to validate Ethereum addresses: 0x followed by exactly 40 hex characters */
+const ETH_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Validates that an address is a valid Ethereum address format.
+ * Prevents URL injection via addresses containing special characters like ? or #.
+ */
+function validateEthAddress(address: string): void {
+  if (!ETH_ADDRESS_REGEX.test(address)) {
+    throw new Error(`Invalid token address format: ${address}. Expected 0x followed by 40 hex characters.`);
+  }
+}
+
 /** Resolve the platform base URL from the optional override or environment. */
 function resolveBaseUrl(baseUrl?: string): string {
   return (
@@ -90,6 +103,9 @@ export function generateTradeLink(
   opts: TradeLinkOptions = {},
   baseUrl?: string,
 ): string {
+  // Security: Validate address format to prevent URL injection
+  validateEthAddress(address);
+
   const base = resolveBaseUrl(baseUrl);
   const params = new URLSearchParams();
 


### PR DESCRIPTION
## Summary

This PR fixes 5 security vulnerabilities identified in the security review (Issues #84, #85, #87, #89, #90).

### Critical Severity

- **#84 - MCP agentFile path traversal**: Added path containment validation in `agentverse.ts` to prevent reading arbitrary files (e.g., `/etc/passwd`, `.env`, SSH keys) via `../../` paths
- **#85 - MCP outputDir arbitrary file writes**: Added path containment validation in `scaffold.ts` to prevent writing files outside the current working directory

### High Severity

- **#87 - Token address validation missing**: Added Ethereum address format validation (`/^0x[a-fA-F0-9]{40}$/`) in:
  - SDK `handoff.ts` - `generateTradeLink()`
  - MCP `tokenize.ts` - `createAndTokenize()`
  - MCP `handoff.ts` - `getTradeLink()`
  - MCP `comments.ts` - `getComments()` and `postComment()`
  
  This prevents URL injection via addresses containing `?` or `#`

### Medium Severity

- **#89 - SDK Retry-After unbounded sleep**: Capped `Retry-After` header wait time to 30 seconds in `client.ts` to prevent DoS via malicious server responses
- **#90 - CLI image URL SSRF**: Added HTTPS scheme validation in CLI `tokenize.ts` to prevent `file://` and internal network URL access

### Already Fixed

- **#86 - Default URL points to staging**: Verified this is already fixed - production is the default when no `AGENT_LAUNCH_ENV` is set

## Files Changed

| File | Changes |
|------|---------|
| `packages/sdk/src/client.ts` | Cap Retry-After to 30s |
| `packages/sdk/src/handoff.ts` | Validate ETH address format |
| `packages/cli/src/commands/tokenize.ts` | Validate image URL scheme |
| `packages/mcp/src/tools/agentverse.ts` | Path containment for agentFile |
| `packages/mcp/src/tools/scaffold.ts` | Path containment for outputDir |
| `packages/mcp/src/tools/tokenize.ts` | Validate ETH address format |
| `packages/mcp/src/tools/handoff.ts` | Validate ETH address format |
| `packages/mcp/src/tools/comments.ts` | Validate ETH address format |

## Test plan

- [ ] Verify SDK builds correctly
- [ ] Test `generateTradeLink()` with invalid addresses (should throw)
- [ ] Test scaffold tools with `../` paths (should throw)
- [ ] Test CLI tokenize with `file://` image URL (should error)
- [ ] Verify normal operations still work

Closes #84, #85, #87, #89, #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)