### PR TITLE
fix: security hardening across SDK, CLI, and MCP

### DIFF
--- a/packages/cli/src/commands/tokenize.ts
+++ b/packages/cli/src/commands/tokenize.ts
@@ -210,7 +210,32 @@ export function registerTokenizeCommand(program: Command): void {
           category: { id: categoryId },
         };
         if (options.description) body.description = options.description;
-        if (options.image) body.image = options.image;
+        if (options.image) {
+          // Validate image URL scheme to prevent SSRF with file:// or other protocols
+          try {
+            const imageUrl = new URL(options.image);
+            if (imageUrl.protocol !== 'https:' && imageUrl.protocol !== 'http:') {
+              if (isJson) {
+                console.log(
+                  JSON.stringify({ error: "--image must be an HTTP or HTTPS URL" }),
+                );
+              } else {
+                console.error("Error: --image must be an HTTP or HTTPS URL");
+              }
+              process.exit(1);
+            }
+          } catch {
+            if (isJson) {
+              console.log(
+                JSON.stringify({ error: "--image must be a valid URL" }),
+              );
+            } else {
+              console.error("Error: --image must be a valid URL");
+            }
+            process.exit(1);
+          }
+          body.image = options.image;
+        }
         if (initialBuyAmount !== undefined)
           body.initialBuyAmount = initialBuyAmount;
 

--- a/packages/mcp/src/tools/agentverse.ts
+++ b/packages/mcp/src/tools/agentverse.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { deployAgent, updateAgent, buildOptimizationChecklist } from 'agentlaunch-sdk';
 import type { AgentverseDeployResult, AgentMetadata, OptimizationCheckItem } from 'agentlaunch-sdk';
 
@@ -34,12 +35,23 @@ export async function deployToAgentverse(args: {
   readme?: string;
   shortDescription?: string;
 }): Promise<DeployToAgentverseResult> {
-  // Read agent source code
-  if (!fs.existsSync(args.agentFile)) {
-    throw new Error(`Agent file not found: ${args.agentFile}`);
+  // Security: resolve and validate agentFile is within cwd to prevent path traversal
+  const resolvedPath = path.resolve(args.agentFile);
+  const cwd = process.cwd();
+  if (!resolvedPath.startsWith(cwd + path.sep) && resolvedPath !== cwd) {
+    throw new Error(
+      `Security: agentFile must be within the current working directory.\n` +
+      `  cwd:       ${cwd}\n` +
+      `  resolved:  ${resolvedPath}`,
+    );
   }
 
-  const sourceCode = fs.readFileSync(args.agentFile, 'utf8');
+  // Read agent source code
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Agent file not found: ${resolvedPath}`);
+  }
+
+  const sourceCode = fs.readFileSync(resolvedPath, 'utf8');
   if (!sourceCode.trim()) {
     throw new Error(`Agent file is empty: ${args.agentFile}`);
   }

--- a/packages/mcp/src/tools/scaffold.ts
+++ b/packages/mcp/src/tools/scaffold.ts
@@ -49,6 +49,16 @@ export async function scaffoldAgent(args: {
     args.outputDir ?? path.join(process.cwd(), args.name.toLowerCase().replace(/\s+/g, '-')),
   );
 
+  // Security: validate outputDir is within cwd to prevent arbitrary file writes
+  const cwd = process.cwd();
+  if (!outputDir.startsWith(cwd + path.sep) && outputDir !== cwd) {
+    throw new Error(
+      `Security: outputDir must be within the current working directory.\n` +
+      `  cwd:       ${cwd}\n` +
+      `  resolved:  ${outputDir}`,
+    );
+  }
+
   // Create base directory and .claude/ subdirectory
   fs.mkdirSync(outputDir, { recursive: true });
   fs.mkdirSync(path.join(outputDir, '.claude'), { recursive: true });
@@ -147,6 +157,16 @@ export async function scaffoldSwarm(args: {
   const outputDir = path.resolve(
     args.outputDir ?? path.join(process.cwd(), args.name.toLowerCase().replace(/\s+/g, '-')),
   );
+
+  // Security: validate outputDir is within cwd to prevent arbitrary file writes
+  const cwd = process.cwd();
+  if (!outputDir.startsWith(cwd + path.sep) && outputDir !== cwd) {
+    throw new Error(
+      `Security: outputDir must be within the current working directory.\n` +
+      `  cwd:       ${cwd}\n` +
+      `  resolved:  ${outputDir}`,
+    );
+  }
 
   // Create base directory and .claude/ subdirectory
   fs.mkdirSync(outputDir, { recursive: true });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -154,9 +154,13 @@ export class AgentLaunchClient {
       const delayMs = 1000 * Math.pow(2, attempt);
       attempt++;
 
-      // Respect Retry-After header if the server sends one
+      // Respect Retry-After header if the server sends one (capped at 30s to
+      // prevent a malicious server from stalling the client indefinitely).
       const retryAfter = response.headers.get('Retry-After');
-      const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : delayMs;
+      const MAX_RETRY_WAIT_MS = 30_000;
+      const waitMs = retryAfter
+        ? Math.min(parseInt(retryAfter, 10) * 1000, MAX_RETRY_WAIT_MS)
+        : delayMs;
 
       await sleep(waitMs);
 

--- a/packages/sdk/src/handoff.ts
+++ b/packages/sdk/src/handoff.ts
@@ -90,6 +90,13 @@ export function generateTradeLink(
   opts: TradeLinkOptions = {},
   baseUrl?: string,
 ): string {
+  // Validate Ethereum address format to prevent URL injection
+  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
+    throw new Error(
+      `generateTradeLink: address must be a valid 0x-prefixed Ethereum address (40 hex chars), got "${address}"`,
+    );
+  }
+
   const base = resolveBaseUrl(baseUrl);
   const params = new URLSearchParams();
 


### PR DESCRIPTION
## Summary

- **MCP agentverse** (#84): Validate `agentFile` path is within `process.cwd()` to prevent arbitrary file reads via path traversal
- **MCP scaffold** (#85): Validate `outputDir` is within `process.cwd()` for both `scaffoldAgent` and `scaffoldSwarm` to prevent arbitrary file writes
- **SDK handoff** (#87): Validate Ethereum address format (`/^0x[a-fA-F0-9]{40}$/`) in `generateTradeLink` to prevent URL injection
- **SDK client** (#89): Cap `Retry-After` header wait to 30 seconds to prevent a malicious server from stalling the client indefinitely
- **CLI tokenize** (#90): Validate `--image` URL scheme is HTTP/HTTPS to prevent SSRF via `file://` or other protocols

Issue #86 (default URL points to staging) is already fixed in `urls.ts` — production is the default when `AGENT_LAUNCH_ENV` is not set to `dev`.

## Test plan

- [ ] Verify MCP `deploy_to_agentverse` rejects paths outside cwd (e.g., `../../etc/passwd`)
- [ ] Verify MCP `scaffold_agent` / `scaffold_swarm` reject outputDir outside cwd
- [ ] Verify `generateTradeLink` throws on malformed addresses
- [ ] Verify SDK client retries are capped at 30s even with large Retry-After header
- [ ] Verify CLI `tokenize --image file:///etc/passwd` is rejected

Addresses: fetchai/launchpadDAO#84, fetchai/launchpadDAO#85, fetchai/launchpadDAO#87, fetchai/launchpadDAO#89, fetchai/launchpadDAO#90

🤖 Generated with [Claude Code](https://claude.com/claude-code)