### PR TITLE
feat: add pre-publish smoke test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,4 +354,45 @@ curl -X POST https://agent-launch.ai/api/faucet/claim \
 
 ---
 
+## Development
+
+### Pre-Publish Testing
+
+Before publishing to npm, run the smoke test suite to verify all packages work as real installs:
+
+```bash
+npm run test:publish
+```
+
+This command:
+
+1. **Builds** all packages
+2. **Packs** tarballs (exactly what `npm publish` uploads)
+3. **Inspects** tarball contents for missing/extra files
+4. **Installs** tarballs in an isolated temp directory (no workspace symlinks)
+5. **Runs 5 smoke tests** against the installed packages
+
+| Test | Verifies |
+|------|----------|
+| SDK ESM | All public exports work via `import` |
+| SDK CJS | All public exports work via `require()` |
+| Templates | Template listing, generation, presets, alias resolution |
+| CLI | Binary runs, `--help` shows all commands, `--version` works |
+| MCP | Binary installed, entry point syntax-valid |
+
+This catches issues that workspace resolution hides: missing `files`, broken exports, missing dependencies, and broken binaries.
+
+### Publishing
+
+After `test:publish` passes, publish in dependency order:
+
+```bash
+npm publish -w packages/sdk
+npm publish -w packages/templates
+npm publish -w packages/cli
+npm publish -w packages/mcp
+```
+
+---
+
 MIT License

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "npm run test --workspaces --if-present",
     "clean": "npm run clean --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
+    "test:publish": "bash scripts/test-publish.sh",
     "deploy": "python3 examples/scripts/deploy-to-agentverse.py",
     "cli": "npx agentlaunch",
     "mcp": "npx agent-launch-mcp"

--- a/scripts/smoke-tests/test-cli.mjs
+++ b/scripts/smoke-tests/test-cli.mjs
@@ -1,0 +1,58 @@
+/**
+ * Smoke test: agentlaunch CLI
+ *
+ * Verifies that the CLI binary runs and shows expected commands.
+ */
+
+import { execSync } from 'node:child_process';
+
+const errors = [];
+
+// ── Test --help ─────────────────────────────────────────────────────
+let helpOutput;
+try {
+  helpOutput = execSync('npx agentlaunch --help', {
+    encoding: 'utf-8',
+    timeout: 15000,
+    env: { ...process.env, NODE_NO_WARNINGS: '1' },
+  });
+} catch (err) {
+  // commander exits 0 on --help but some versions throw
+  helpOutput = err.stdout || err.stderr || '';
+}
+
+if (!helpOutput || helpOutput.length < 50) {
+  errors.push(`CLI --help output too short or empty (${helpOutput?.length || 0} chars)`);
+} else {
+  // Verify expected subcommands appear
+  const expectedCommands = ['list', 'status', 'deploy', 'tokenize', 'config', 'buy', 'sell'];
+  for (const cmd of expectedCommands) {
+    if (!helpOutput.includes(cmd)) {
+      errors.push(`CLI --help missing command: "${cmd}"`);
+    }
+  }
+}
+
+// ── Test --version ──────────────────────────────────────────────────
+let versionOutput;
+try {
+  versionOutput = execSync('npx agentlaunch --version', {
+    encoding: 'utf-8',
+    timeout: 10000,
+    env: { ...process.env, NODE_NO_WARNINGS: '1' },
+  });
+} catch (err) {
+  versionOutput = err.stdout || err.stderr || '';
+}
+
+if (!versionOutput || !versionOutput.trim().match(/^\d+\.\d+\.\d+/)) {
+  errors.push(`CLI --version unexpected output: "${versionOutput?.trim()}"`);
+}
+
+if (errors.length > 0) {
+  console.error('CLI failures:');
+  errors.forEach(e => console.error(`  - ${e}`));
+  process.exit(1);
+}
+
+console.log(`CLI: binary runs, help shows ${helpOutput.split('\n').length} lines, version ${versionOutput.trim()}`);

--- a/scripts/smoke-tests/test-mcp.mjs
+++ b/scripts/smoke-tests/test-mcp.mjs
@@ -1,0 +1,57 @@
+/**
+ * Smoke test: agent-launch-mcp
+ *
+ * Verifies that the MCP server binary exists and is executable.
+ * We can't fully start it (it expects stdio MCP protocol), but we
+ * verify the binary is installed and importable.
+ */
+
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { execSync } from 'node:child_process';
+
+const errors = [];
+
+// ── Check binary exists ─────────────────────────────────────────────
+const binPath = resolve('node_modules/.bin/agent-launch-mcp');
+if (!existsSync(binPath)) {
+  errors.push(`MCP binary not installed at ${binPath}`);
+}
+
+// ── Check the entry point is valid JS ───────────────────────────────
+// We use node --check to syntax-check without running (avoids stdio hang)
+try {
+  const entryPoint = resolve('node_modules/agent-launch-mcp/dist/index.js');
+  if (existsSync(entryPoint)) {
+    execSync(`node --check "${entryPoint}"`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+  } else {
+    errors.push(`MCP entry point not found: ${entryPoint}`);
+  }
+} catch (err) {
+  errors.push(`MCP entry point syntax check failed: ${err.message}`);
+}
+
+// ── Verify package.json bin field resolved ───────────────────────────
+try {
+  const pkgPath = resolve('node_modules/agent-launch-mcp/package.json');
+  if (existsSync(pkgPath)) {
+    const { readFileSync } = await import('node:fs');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    if (!pkg.bin || !pkg.bin['agent-launch-mcp']) {
+      errors.push('MCP package.json missing bin field for agent-launch-mcp');
+    }
+  }
+} catch (err) {
+  errors.push(`MCP package.json check failed: ${err.message}`);
+}
+
+if (errors.length > 0) {
+  console.error('MCP failures:');
+  errors.forEach(e => console.error(`  - ${e}`));
+  process.exit(1);
+}
+
+console.log('MCP: binary installed, entry point valid');

--- a/scripts/smoke-tests/test-sdk-cjs.cjs
+++ b/scripts/smoke-tests/test-sdk-cjs.cjs
@@ -1,0 +1,60 @@
+/**
+ * Smoke test: agentlaunch-sdk CJS require
+ *
+ * Verifies that the SDK works via CommonJS require().
+ * This catches dual-export (ESM/CJS) issues.
+ */
+
+const sdk = require('agentlaunch-sdk');
+
+const errors = [];
+
+// Check key exports exist
+const expected = [
+  'AgentLaunch',
+  'AgentLaunchClient',
+  'AgentLaunchError',
+  'tokenize',
+  'getToken',
+  'listTokens',
+  'generateDeployLink',
+  'generateTradeLink',
+  'generateBuyLink',
+  'generateSellLink',
+  'getApiUrl',
+  'getFrontendUrl',
+];
+
+for (const name of expected) {
+  if (!(name in sdk)) {
+    errors.push(`Missing CJS export: ${name}`);
+  }
+}
+
+// Verify constructors work
+try {
+  const client = new sdk.AgentLaunchClient({ apiKey: 'test-key' });
+  if (typeof client.get !== 'function' || typeof client.post !== 'function') {
+    errors.push('CJS AgentLaunchClient missing get/post methods');
+  }
+} catch (e) {
+  errors.push(`CJS AgentLaunchClient constructor failed: ${e.message}`);
+}
+
+// Verify pure functions work
+try {
+  const link = sdk.generateDeployLink(99);
+  if (!link.includes('99')) {
+    errors.push(`CJS generateDeployLink(99) unexpected: ${link}`);
+  }
+} catch (e) {
+  errors.push(`CJS generateDeployLink failed: ${e.message}`);
+}
+
+if (errors.length > 0) {
+  console.error('SDK CJS failures:');
+  errors.forEach(e => console.error(`  - ${e}`));
+  process.exit(1);
+}
+
+console.log(`SDK CJS: ${expected.length} exports verified`);

--- a/scripts/smoke-tests/test-sdk-esm.mjs
+++ b/scripts/smoke-tests/test-sdk-esm.mjs
@@ -1,0 +1,96 @@
+/**
+ * Smoke test: agentlaunch-sdk ESM imports
+ *
+ * Verifies that all public exports are accessible via ESM import.
+ */
+
+import {
+  // Fluent API
+  AgentLaunch,
+  // Core client
+  AgentLaunchClient,
+  // Error class
+  AgentLaunchError,
+  // Token operations
+  tokenize, getToken, listTokens,
+  // Market operations
+  getTokenPrice, getTokenHolders, calculateBuy, calculateSell, getPlatformStats,
+  // Handoff links
+  generateDeployLink, generateTradeLink, generateBuyLink, generateSellLink,
+  // Agent operations
+  authenticate, getMyAgents,
+  // Agentverse deployment
+  createAgent, uploadCode, setSecret, startAgent, deployAgent,
+  // Comments
+  getComments, postComment,
+  // URL resolution
+  getApiUrl, getFrontendUrl,
+} from 'agentlaunch-sdk';
+
+const errors = [];
+
+// Verify classes exist and are constructable
+try {
+  const sdk = new AgentLaunch({ apiKey: 'test-key' });
+  if (!sdk.tokens || !sdk.market || !sdk.handoff || !sdk.agents) {
+    errors.push('AgentLaunch missing namespaces (tokens, market, handoff, agents)');
+  }
+} catch (e) {
+  errors.push(`AgentLaunch constructor failed: ${e.message}`);
+}
+
+try {
+  const client = new AgentLaunchClient({ apiKey: 'test-key' });
+  if (typeof client.get !== 'function' || typeof client.post !== 'function') {
+    errors.push('AgentLaunchClient missing get/post methods');
+  }
+} catch (e) {
+  errors.push(`AgentLaunchClient constructor failed: ${e.message}`);
+}
+
+// Verify standalone functions are functions
+const fns = {
+  tokenize, getToken, listTokens,
+  getTokenPrice, getTokenHolders, calculateBuy, calculateSell, getPlatformStats,
+  generateDeployLink, generateTradeLink, generateBuyLink, generateSellLink,
+  authenticate, getMyAgents,
+  createAgent, uploadCode, setSecret, startAgent, deployAgent,
+  getComments, postComment,
+  getApiUrl, getFrontendUrl,
+};
+
+for (const [name, fn] of Object.entries(fns)) {
+  if (typeof fn !== 'function') {
+    errors.push(`Expected ${name} to be a function, got ${typeof fn}`);
+  }
+}
+
+// Verify error class
+try {
+  const err = new AgentLaunchError('test', 'TEST_ERROR');
+  if (!(err instanceof Error)) {
+    errors.push('AgentLaunchError is not an Error subclass');
+  }
+} catch (e) {
+  errors.push(`AgentLaunchError failed: ${e.message}`);
+}
+
+// Verify handoff link generation (pure function, no network)
+const deployLink = generateDeployLink(42);
+if (!deployLink.includes('42')) {
+  errors.push(`generateDeployLink(42) returned unexpected: ${deployLink}`);
+}
+
+const testAddr = '0x0000000000000000000000000000000000000001';
+const buyLink = generateBuyLink(testAddr, '10');
+if (!buyLink.includes(testAddr) || !buyLink.includes('buy')) {
+  errors.push(`generateBuyLink returned unexpected: ${buyLink}`);
+}
+
+if (errors.length > 0) {
+  console.error('SDK ESM failures:');
+  errors.forEach(e => console.error(`  - ${e}`));
+  process.exit(1);
+}
+
+console.log(`SDK ESM: ${Object.keys(fns).length + 3} exports verified`);

--- a/scripts/smoke-tests/test-templates.mjs
+++ b/scripts/smoke-tests/test-templates.mjs
@@ -1,0 +1,96 @@
+/**
+ * Smoke test: agentlaunch-templates
+ *
+ * Verifies template listing, generation, and presets work correctly.
+ */
+
+import {
+  listTemplates,
+  getTemplate,
+  generateFromTemplate,
+  getPreset,
+  listPresets,
+  RULES,
+  SKILLS,
+} from 'agentlaunch-templates';
+
+const errors = [];
+
+// ── List templates ──────────────────────────────────────────────────
+const templates = listTemplates();
+if (!Array.isArray(templates) || templates.length === 0) {
+  errors.push(`listTemplates() returned empty or non-array: ${JSON.stringify(templates)}`);
+}
+
+// Verify expected templates exist (swarm-starter is an alias for genesis)
+const expectedTemplates = ['chat-memory', 'custom', 'genesis'];
+for (const name of expectedTemplates) {
+  const found = templates.some(t => t.name === name);
+  if (!found) {
+    errors.push(`Template "${name}" missing from listTemplates()`);
+  }
+}
+
+// Verify swarm-starter alias resolves via getTemplate
+const swarmStarter = getTemplate('swarm-starter');
+if (!swarmStarter) {
+  errors.push('getTemplate("swarm-starter") alias did not resolve');
+}
+
+// ── Get individual template ─────────────────────────────────────────
+const chatMemory = getTemplate('chat-memory');
+if (!chatMemory) {
+  errors.push('getTemplate("chat-memory") returned null/undefined');
+} else {
+  if (!chatMemory.name || !chatMemory.description) {
+    errors.push('chat-memory template missing name or description');
+  }
+}
+
+// ── Generate from template ──────────────────────────────────────────
+const result = generateFromTemplate('chat-memory', { agent_name: 'SmokeTestBot' });
+if (!result || typeof result !== 'object') {
+  errors.push(`generateFromTemplate returned invalid: ${typeof result}`);
+} else {
+  if (!result.code || typeof result.code !== 'string' || result.code.length < 50) {
+    errors.push('Generated code is empty or too short');
+  }
+  if (!result.readme || typeof result.readme !== 'string') {
+    errors.push('Generated readme is missing');
+  }
+  // Verify the agent name appears in output
+  if (!result.code.includes('SmokeTestBot') && !result.readme.includes('SmokeTestBot')) {
+    errors.push('Agent name "SmokeTestBot" not found in generated output');
+  }
+}
+
+// ── Presets ──────────────────────────────────────────────────────────
+const presets = listPresets();
+if (!Array.isArray(presets) || presets.length === 0) {
+  errors.push('listPresets() returned empty');
+}
+
+const oracle = getPreset('oracle');
+if (!oracle) {
+  errors.push('getPreset("oracle") returned null/undefined');
+} else {
+  if (!oracle.variables || typeof oracle.variables !== 'object') {
+    errors.push('Oracle preset missing variables');
+  }
+}
+
+// ── Claude context exports ──────────────────────────────────────────
+if (!RULES || typeof RULES !== 'object') {
+  errors.push('RULES export missing or invalid');
+}
+if (!SKILLS || typeof SKILLS !== 'object') {
+  errors.push('SKILLS export missing or invalid');
+}
+
+if (errors.length > 0) {
+  console.error('Templates failures:');
+  errors.forEach(e => console.error(`  - ${e}`));
+  process.exit(1);
+}
+
+console.log(`Templates: ${templates.length} templates, ${presets.length} presets verified`);

--- a/scripts/test-publish.sh
+++ b/scripts/test-publish.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# test-publish.sh — Test all packages as if installed from npm.
+#
+# Builds, packs tarballs, installs them in an isolated temp directory,
+# and runs smoke tests to verify exports, binaries, and interop.
+#
+# Usage:
+#   npm run test:publish        # from repo root
+#   bash scripts/test-publish.sh
+#
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+TEMP_DIR=""
+cleanup() {
+  if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+log()  { echo -e "${GREEN}[test-publish]${NC} $*"; }
+warn() { echo -e "${YELLOW}[test-publish]${NC} $*"; }
+fail() { echo -e "${RED}[test-publish]${NC} $*"; exit 1; }
+step() { echo -e "\n${BOLD}── $* ──${NC}"; }
+
+# ── Step 1: Build ──────────────────────────────────────────────────────
+step "Building all packages"
+cd "$ROOT_DIR"
+npm run build
+
+# ── Step 2: Pack ───────────────────────────────────────────────────────
+step "Packing tarballs"
+TEMP_DIR=$(mktemp -d)
+PACK_DIR="$TEMP_DIR/packs"
+mkdir -p "$PACK_DIR"
+
+# npm pack outputs the filename to stdout
+SDK_TGZ=$(cd "$ROOT_DIR/packages/sdk" && npm pack --pack-destination "$PACK_DIR" 2>/dev/null)
+TEMPLATES_TGZ=$(cd "$ROOT_DIR/packages/templates" && npm pack --pack-destination "$PACK_DIR" 2>/dev/null)
+CLI_TGZ=$(cd "$ROOT_DIR/packages/cli" && npm pack --pack-destination "$PACK_DIR" 2>/dev/null)
+MCP_TGZ=$(cd "$ROOT_DIR/packages/mcp" && npm pack --pack-destination "$PACK_DIR" 2>/dev/null)
+
+log "SDK:       $SDK_TGZ"
+log "Templates: $TEMPLATES_TGZ"
+log "CLI:       $CLI_TGZ"
+log "MCP:       $MCP_TGZ"
+
+# Verify all tarballs exist
+for tgz in "$SDK_TGZ" "$TEMPLATES_TGZ" "$CLI_TGZ" "$MCP_TGZ"; do
+  [ -f "$PACK_DIR/$tgz" ] || fail "Tarball not found: $PACK_DIR/$tgz"
+done
+
+# ── Step 3: Show tarball contents ──────────────────────────────────────
+step "Checking tarball contents"
+for tgz in "$SDK_TGZ" "$TEMPLATES_TGZ" "$CLI_TGZ" "$MCP_TGZ"; do
+  echo -e "${BOLD}$tgz${NC}"
+  tar tzf "$PACK_DIR/$tgz" | head -20
+  FILE_COUNT=$(tar tzf "$PACK_DIR/$tgz" | wc -l | tr -d ' ')
+  echo "  ($FILE_COUNT files total)"
+  echo ""
+done
+
+# ── Step 4: Create isolated test project ───────────────────────────────
+step "Creating isolated test project"
+TEST_DIR="$TEMP_DIR/test-project"
+mkdir -p "$TEST_DIR"
+
+cat > "$TEST_DIR/package.json" <<'EOF'
+{
+  "name": "test-publish-smoke",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}
+EOF
+
+# ── Step 5: Install tarballs ──────────────────────────────────────────
+step "Installing from tarballs (simulates npm install)"
+cd "$TEST_DIR"
+npm install \
+  "$PACK_DIR/$SDK_TGZ" \
+  "$PACK_DIR/$TEMPLATES_TGZ" \
+  "$PACK_DIR/$CLI_TGZ" \
+  "$PACK_DIR/$MCP_TGZ" \
+  2>&1
+
+# Show what got installed
+log "Installed packages:"
+ls node_modules/ | grep -E "^(agentlaunch|agent-launch)" || true
+
+# ── Step 6: Copy and run smoke tests ──────────────────────────────────
+step "Running smoke tests"
+cp "$SCRIPT_DIR/smoke-tests/"* "$TEST_DIR/" 2>/dev/null || true
+
+PASSED=0
+FAILED=0
+TESTS=()
+
+# Discover all test files (.mjs and .cjs)
+for test_file in "$TEST_DIR"/test-*.mjs "$TEST_DIR"/test-*.cjs; do
+  [ -f "$test_file" ] && TESTS+=("$(basename "$test_file")")
+done
+
+if [ ${#TESTS[@]} -eq 0 ]; then
+  fail "No smoke tests found in scripts/smoke-tests/"
+fi
+
+for test in "${TESTS[@]}"; do
+  if node "$TEST_DIR/$test" 2>&1; then
+    echo -e "  ${GREEN}PASS${NC}  $test"
+    PASSED=$((PASSED + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}  $test"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+# ── Results ────────────────────────────────────────────────────────────
+echo ""
+step "Results"
+echo -e "  ${GREEN}$PASSED passed${NC}"
+[ $FAILED -gt 0 ] && echo -e "  ${RED}$FAILED failed${NC}"
+echo ""
+
+if [ $FAILED -gt 0 ]; then
+  fail "Some smoke tests failed. Fix issues before publishing."
+fi
+
+log "All smoke tests passed. Safe to publish."


### PR DESCRIPTION
## Summary

- Adds `npm run test:publish` — packs all 4 packages as tarballs, installs them in an isolated temp directory (no workspace symlinks), and runs 5 smoke tests
- Tests SDK ESM imports, SDK CJS require, template generation/presets, CLI binary, and MCP binary
- Catches issues that workspace resolution hides: missing `files`, broken exports, missing dependencies, broken binaries
- Documents the workflow in the README Development section

## Test plan

- [x] `npm run test:publish` passes (5/5 smoke tests)
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)