### PR TITLE
fix: resolve open issues #8, #9, #10, #11, #12, #13

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -849,6 +849,23 @@ AGENT_ADDRESS=${successful[0].address}
           }
 
           // Default: Claude Code
+          // Check if Claude Code is available before launching
+          let claudeAvailable = false;
+          try {
+            execSync("claude --version", { stdio: "ignore", timeout: 5000 });
+            claudeAvailable = true;
+          } catch {
+            // Claude Code not installed or not in PATH
+          }
+
+          if (!claudeAvailable) {
+            console.log(`\n  Claude Code is not installed or not in PATH.`);
+            console.log(`  Install it from: https://docs.anthropic.com/en/docs/claude-code`);
+            console.log(`\n  To open your project later:`);
+            console.log(`    cd ${dirName} && claude`);
+            return;
+          }
+
           console.log(`\n  Launching Claude Code...`);
 
           let welcomePrompt: string;

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -58,10 +58,14 @@ export function registerScaffoldCommand(program: Command): void {
       "Agent type: chat-memory (default), swarm-starter, custom, price-monitor, trading-bot, data-analyzer, research, gifter",
       "chat-memory",
     )
+    .option(
+      "--template <template>",
+      "Alias for --type: select agent template by name",
+    )
     .option("--json", "Output only JSON (machine-readable)")
-    .action((name: string, options: { type: string; json?: boolean }) => {
+    .action((name: string, options: { type: string; template?: string; json?: boolean }) => {
       const isJson = options.json === true;
-      const rawType = options.type;
+      const rawType = options.template ?? options.type;
 
       // Resolve the template name: legacy map first, then direct name
       const templateName = LEGACY_TYPE_MAP[rawType] ?? rawType;

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -74,7 +74,7 @@ After editing the config, restart Claude Code / Claude Desktop.
 
 ---
 
-## Available Tools
+## Available Tools (21)
 
 ### Discovery — read platform data, no API key required
 
@@ -129,6 +129,23 @@ After editing the config, restart Claude Code / Claude Desktop.
 | Tool | Description |
 |------|-------------|
 | `create_and_tokenize` | End-to-end combo: calls `POST /tokenize` with a live Agentverse agent address and returns tokenId, deploy handoff link, and pre-filled trade link in a single step. Accepts optional `maxWalletAmount` (0\|1\|2), `initialBuyAmount` (FET string), and `category` (number). |
+
+### Swarm — scaffold and deploy agent swarms
+
+| Tool | Description |
+|------|-------------|
+| `scaffold_swarm` | Scaffold a swarm-starter agent from a preset (oracle, brain, analyst, etc.). Creates a complete agent project with commerce stack, ready to deploy. |
+| `check_agent_commerce` | Check an agent's commerce status: revenue, pricing, balance, effort mode, and cross-holdings. |
+| `network_status` | Check the status of an agent swarm: per-agent revenue, total GDP, health, and cross-holdings. |
+| `deploy_swarm` | Deploy a complete agent swarm. Deploys each agent in sequence, sets secrets, starts them, returns addresses and status. |
+
+### On-chain trading — buy/sell tokens on bonding curves
+
+| Tool | Description |
+|------|-------------|
+| `buy_tokens` | Buy tokens on a bonding curve contract. Supports `dryRun=true` for preview without wallet. Requires `WALLET_PRIVATE_KEY` env var for live trades. |
+| `sell_tokens` | Sell tokens on a bonding curve contract. Supports `dryRun=true` for preview. Requires `WALLET_PRIVATE_KEY` for live trades. |
+| `get_wallet_balances` | Get wallet balances for BNB (gas), FET, and a specific token. Requires `WALLET_PRIVATE_KEY` env var. |
 
 ---
 

--- a/packages/mcp/src/tools/handoff.ts
+++ b/packages/mcp/src/tools/handoff.ts
@@ -1,4 +1,4 @@
-import { AgentLaunchClient, getFrontendUrl } from 'agentlaunch-sdk';
+import { AgentLaunchClient, getFrontendUrl, getToken } from 'agentlaunch-sdk';
 import type { Token } from 'agentlaunch-sdk';
 
 const client = new AgentLaunchClient();
@@ -208,6 +208,37 @@ export async function getTradeLink(args: {
   // Security: Validate address format to prevent URL injection
   validateEthAddress(args.address);
 
+  // Check if token has graduated from bonding curve to DEX
+  let token: Token | undefined;
+  try {
+    token = await getToken(args.address);
+  } catch {
+    // If we can't fetch token info, fall through to bonding curve link
+  }
+
+  if (token && (token.listed || token.status === 'listed')) {
+    // Token has graduated — direct to DEX (PancakeSwap on BSC)
+    const dexBaseUrl = token.chainId === 56
+      ? 'https://pancakeswap.finance/swap'
+      : 'https://pancakeswap.finance/swap';
+    const dexLink = `${dexBaseUrl}?outputCurrency=${args.address}`;
+
+    return {
+      link: dexLink,
+      instructions: {
+        action: `${args.action === 'buy' ? 'Buy' : 'Sell'} tokens on DEX`,
+        steps: [
+          'This token has graduated and is now trading on PancakeSwap',
+          'Click the link to open PancakeSwap',
+          'Connect your wallet',
+          `${args.action === 'buy' ? 'Swap FET for tokens' : 'Swap tokens for FET'}`,
+          'Confirm the transaction in your wallet',
+        ],
+      },
+    };
+  }
+
+  // Token is still on bonding curve — generate bonding curve trade link
   const params = new URLSearchParams();
   params.set('action', args.action);
   if (args.amount) {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -440,8 +440,11 @@ try {
   const { data } = await tokenize({ agentAddress: 'agent1q...' });
 } catch (err) {
   if (err instanceof AgentLaunchError) {
-    console.error(`HTTP ${err.status}: ${err.message}`);
+    console.error(`HTTP ${err.status} [${err.code}]: ${err.message}`);
     console.error('Server message:', err.serverMessage);
+    if (err.code === 'RATE_LIMITED' && err.retryAfterMs) {
+      console.error(`Retry after ${err.retryAfterMs}ms`);
+    }
   }
 }
 ```
@@ -450,6 +453,9 @@ try {
 - `status` — HTTP status code (0 for network-level failures or missing API key)
 - `message` — Human-readable error message
 - `serverMessage` — Original server error message when available
+- `code` — Semantic error code for switch-based handling (`'UNAUTHORIZED'` | `'FORBIDDEN'` | `'NOT_FOUND'` | `'RATE_LIMITED'` | `'VALIDATION_ERROR'` | `'INTERNAL_ERROR'` | `'NETWORK_ERROR'`)
+- `details` — Additional error details when available (optional)
+- `retryAfterMs` — Retry delay in ms for rate-limited requests (optional)
 
 ## Platform Information
 

--- a/packages/templates/src/registry.ts
+++ b/packages/templates/src/registry.ts
@@ -8,7 +8,6 @@
  */
 
 import { template as chatMemoryTemplate } from "./templates/chat-memory.js";
-import { template as genesisTemplate } from "./templates/genesis.js";
 import { template as customTemplate } from "./templates/custom.js";
 import { template as priceMonitorTemplate } from "./templates/price-monitor.js";
 import { template as tradingBotTemplate } from "./templates/trading-bot.js";
@@ -54,7 +53,6 @@ export interface AgentTemplate {
 
 const TEMPLATES: AgentTemplate[] = [
   chatMemoryTemplate,  // Base template - recommended starting point
-  genesisTemplate,
   customTemplate,
   priceMonitorTemplate,
   tradingBotTemplate,
@@ -66,11 +64,12 @@ const TEMPLATES: AgentTemplate[] = [
 /**
  * Template aliases for backward compatibility and renaming.
  * Maps user-facing names to internal template names.
- * "swarm-starter" is the primary user-facing name for the genesis template.
+ * "swarm-starter" maps to "custom" (genesis template was removed).
  * "genesis" is kept as a legacy alias.
  */
 const TEMPLATE_ALIASES: Record<string, string> = {
-  "swarm-starter": "genesis",
+  "swarm-starter": "custom",
+  "genesis": "custom",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/templates/src/templates/chat-memory.ts
+++ b/packages/templates/src/templates/chat-memory.ts
@@ -51,8 +51,15 @@ from uagents_core.contrib.protocols.chat import (
     ChatMessage,
     EndSessionContent,
     TextContent,
-    chat_protocol_spec,
 )
+try:
+    from uagents_core.contrib.protocols.chat import create_protocol as _create_chat
+except ImportError:
+    _create_chat = None
+try:
+    from uagents_core.contrib.protocols.chat import chat_protocol_spec as _chat_spec
+except ImportError:
+    _chat_spec = None
 
 import json
 import os
@@ -129,7 +136,7 @@ async def reply(ctx: Context, sender: str, text: str, end: bool = False) -> None
 
 memory = ConversationMemory(max_messages=MEMORY_SIZE)
 agent = Agent()
-chat_proto = Protocol(spec=chat_protocol_spec)
+chat_proto = _create_chat() if _create_chat else Protocol(spec=_chat_spec)
 
 @chat_proto.on_message(ChatMessage)
 async def handle_chat(ctx: Context, sender: str, msg: ChatMessage) -> None:

--- a/packages/templates/src/templates/custom.ts
+++ b/packages/templates/src/templates/custom.ts
@@ -61,8 +61,15 @@ from uagents_core.contrib.protocols.chat import (
     ChatMessage,
     EndSessionContent,
     TextContent,
-    chat_protocol_spec,
 )
+try:
+    from uagents_core.contrib.protocols.chat import create_protocol as _create_chat
+except ImportError:
+    _create_chat = None
+try:
+    from uagents_core.contrib.protocols.chat import chat_protocol_spec as _chat_spec
+except ImportError:
+    _chat_spec = None
 
 import json
 import os
@@ -364,7 +371,7 @@ revenue = Revenue(cache)
 business = CustomBusiness()
 
 agent = Agent()
-chat_proto = Protocol(spec=chat_protocol_spec)
+chat_proto = _create_chat() if _create_chat else Protocol(spec=_chat_spec)
 
 
 @chat_proto.on_message(ChatMessage)

--- a/packages/templates/src/templates/data-analyzer.ts
+++ b/packages/templates/src/templates/data-analyzer.ts
@@ -76,8 +76,15 @@ from uagents_core.contrib.protocols.chat import (
     ChatMessage,
     EndSessionContent,
     TextContent,
-    chat_protocol_spec,
 )
+try:
+    from uagents_core.contrib.protocols.chat import create_protocol as _create_chat
+except ImportError:
+    _create_chat = None
+try:
+    from uagents_core.contrib.protocols.chat import chat_protocol_spec as _chat_spec
+except ImportError:
+    _chat_spec = None
 
 import json
 import os
@@ -471,7 +478,7 @@ revenue = Revenue(cache)
 business = DataAnalyzerBusiness(cache)
 
 agent = Agent()
-chat_proto = Protocol(spec=chat_protocol_spec)
+chat_proto = _create_chat() if _create_chat else Protocol(spec=_chat_spec)
 
 
 @chat_proto.on_message(ChatMessage)

--- a/packages/templates/src/templates/gifter.ts
+++ b/packages/templates/src/templates/gifter.ts
@@ -100,8 +100,15 @@ from uagents_core.contrib.protocols.chat import (
     ChatMessage,
     EndSessionContent,
     TextContent,
-    chat_protocol_spec,
 )
+try:
+    from uagents_core.contrib.protocols.chat import create_protocol as _create_chat
+except ImportError:
+    _create_chat = None
+try:
+    from uagents_core.contrib.protocols.chat import chat_protocol_spec as _chat_spec
+except ImportError:
+    _chat_spec = None
 
 import json
 import os
@@ -628,7 +635,7 @@ revenue = Revenue(cache)
 business = GifterBusiness()
 
 agent = Agent()
-chat_proto = Protocol(spec=chat_protocol_spec)
+chat_proto = _create_chat() if _create_chat else Protocol(spec=_chat_spec)
 
 
 @chat_proto.on_message(ChatMessage)

--- a/packages/templates/src/templates/price-monitor.ts
+++ b/packages/templates/src/templates/price-monitor.ts
@@ -80,8 +80,15 @@ from uagents_core.contrib.protocols.chat import (
     ChatMessage,
     EndSessionContent,
     TextContent,
-    chat_protocol_spec,
 )
+try:
+    from uagents_core.contrib.protocols.chat import create_protocol as _create_chat
+except ImportError:
+    _create_chat = None
+try:
+    from uagents_core.contrib.protocols.chat import chat_protocol_spec as _chat_spec
+except ImportError:
+    _chat_spec = None
 
 import json
 import os
@@ -484,7 +491,7 @@ revenue = Revenue(cache)
 business = PriceMonitorBusiness()
 
 agent = Agent()
-chat_proto = Protocol(spec=chat_protocol_spec)
+chat_proto = _create_chat() if _create_chat else Protocol(spec=_chat_spec)
 
 
 @chat_proto.on_message(ChatMessage)

--- a/packages/templates/src/templates/research.ts
+++ b/packages/templates/src/templates/research.ts
@@ -81,8 +81,15 @@ from uagents_core.contrib.protocols.chat import (
     ChatMessage,
     EndSessionContent,
     TextContent,
-    chat_protocol_spec,
 )
+try:
+    from uagents_core.contrib.protocols.chat import create_protocol as _create_chat
+except ImportError:
+    _create_chat = None
+try:
+    from uagents_core.contrib.protocols.chat import chat_protocol_spec as _chat_spec
+except ImportError:
+    _chat_spec = None
 
 import json
 import os
@@ -500,7 +507,7 @@ revenue = Revenue(cache)
 business = ResearchBusiness(cache)
 
 agent = Agent()
-chat_proto = Protocol(spec=chat_protocol_spec)
+chat_proto = _create_chat() if _create_chat else Protocol(spec=_chat_spec)
 
 
 @chat_proto.on_message(ChatMessage)

--- a/packages/templates/src/templates/trading-bot.ts
+++ b/packages/templates/src/templates/trading-bot.ts
@@ -82,8 +82,15 @@ from uagents_core.contrib.protocols.chat import (
     ChatMessage,
     EndSessionContent,
     TextContent,
-    chat_protocol_spec,
 )
+try:
+    from uagents_core.contrib.protocols.chat import create_protocol as _create_chat
+except ImportError:
+    _create_chat = None
+try:
+    from uagents_core.contrib.protocols.chat import chat_protocol_spec as _chat_spec
+except ImportError:
+    _chat_spec = None
 
 import json
 import os
@@ -466,7 +473,7 @@ revenue = Revenue(cache)
 business = TradingBotBusiness()
 
 agent = Agent()
-chat_proto = Protocol(spec=chat_protocol_spec)
+chat_proto = _create_chat() if _create_chat else Protocol(spec=_chat_spec)
 
 
 @chat_proto.on_message(ChatMessage)


### PR DESCRIPTION
## Summary

Fixes all 6 open bug/enhancement issues:

- **#8** CLI prompts for Claude Code login: Added availability check before spawning `claude` — gracefully handles missing/uninstalled Claude Code
- **#9** Agent fails to start (missing `create_protocol`): Added compatibility shim in all 7 templates to support both `create_protocol()` (new API) and `Protocol(spec=chat_protocol_spec)` (legacy API)
- **#10** CLI missing `--template` flag: Added `--template` as alias for `--type` in scaffold command. Buy/sell commands already exist and are registered.
- **#11** SDK API shape mismatch: Updated SDK README to document all `AgentLaunchError` properties (`code`, `details`, `retryAfterMs`) with usage example
- **#12** MCP tool count mismatch: Added 7 missing tools to MCP README (swarm, trading sections), updated header to show correct count of 21
- **#13** MCP `buy_tokens` generates wrong link for graduated tokens: `get_trade_link` now checks token's `listed` status and returns PancakeSwap DEX link for graduated tokens

Also fixes broken genesis template import in registry (leftover from PR #6 cleanup).

## Test plan
- [x] `npm run build` passes (all 4 packages compile)
- [ ] Verify `agentlaunch scaffold my-agent --template research` works
- [ ] Verify `agentlaunch create` gracefully handles missing Claude Code
- [ ] Verify MCP `get_trade_link` returns DEX link for graduated tokens

Closes #8, #9, #10, #11, #12, #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)