### PR TITLE
security: add backup warnings for wallet .env file

### DIFF
--- a/docs/wallet-auth.md
+++ b/docs/wallet-auth.md
@@ -186,11 +186,31 @@ interface WalletAuthResult {
 
 ## Security Considerations
 
-1. **Never log private keys** — The SDK never logs the private key
-2. **Prefer env vars** — Use `WALLET_PRIVATE_KEY` in `.env` instead of CLI flags
-3. **Shell history** — Using `--private-key` flag leaves the key in shell history
-4. **Memory handling** — Private key is only held in memory during authentication
-5. **Token storage** — Store the resulting API key securely (e.g., in `.env`)
+### Back Up Your .env File
+
+Your `.env` file contains your wallet private key. This wallet can hold real funds (FET, tokens, etc.).
+
+- **Back it up** — Store a copy somewhere safe (password manager, encrypted drive, secure backup)
+- **Never commit to git** — Add `.env` to your `.gitignore` (the CLI does this automatically)
+- **Never share** — Don't send your `.env` file to anyone or paste it in chat
+
+If you lose your `.env` file and have no backup, you lose access to any funds in that wallet.
+
+### Best Practices
+
+1. **Back up immediately** — As soon as you generate a wallet, back up your `.env`
+2. **Use env vars** — Use `WALLET_PRIVATE_KEY` in `.env` instead of CLI flags
+3. **Avoid shell history** — Using `--private-key` flag leaves the key in shell history
+4. **One wallet per project** — Keep wallets isolated to limit blast radius
+5. **Rotate API keys** — API keys expire after 30 days by default; regenerate as needed
+
+### Cryptographic Safety
+
+The wallet generation and authentication are cryptographically secure:
+
+- **Wallet generation** — Uses `ethers.Wallet.createRandom()` with CSPRNG (cryptographically secure pseudo-random number generator)
+- **Signing** — Standard secp256k1 ECDSA with ADR-036 format (Cosmos standard)
+- **Libraries** — All crypto operations use audited, industry-standard libraries (`ethers`, `@cosmjs/crypto`)
 
 ## Error Handling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2151,7 +2151,7 @@
     },
     "packages/cli": {
       "name": "agentlaunch",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "license": "MIT",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.0",
@@ -2224,12 +2224,12 @@
     },
     "packages/mcp": {
       "name": "agent-launch-mcp",
-      "version": "2.3.7",
+      "version": "2.3.8",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.0",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "agentlaunch-sdk": "^0.2.11",
-        "agentlaunch-templates": "0.4.6",
+        "agentlaunch-templates": "0.4.11",
         "bech32": "^2.0.0",
         "dotenv": "^17.3.1",
         "ethers": "^6.0.0"
@@ -2293,15 +2293,6 @@
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
       "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w==",
       "license": "Apache-2.0"
-    },
-    "packages/mcp/node_modules/agentlaunch-templates": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/agentlaunch-templates/-/agentlaunch-templates-0.4.6.tgz",
-      "integrity": "sha512-0erqUILG1QgwLFBLXkZb1kcjoiU6nuuQ6xt8Qw4QNDsl3XhhNn1gVZBRWsXIz/rIqc9hEQWsXHjoWkx3MInNuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "packages/sdk": {
       "name": "agentlaunch-sdk",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-launch/cli",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-launch/cli",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentlaunch",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "CLI for AgentLaunch — scaffold, deploy, and tokenize AI agents from the command line",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -260,6 +260,14 @@ export function registerAuthCommand(program: Command): void {
         console.log("=".repeat(50));
         if (generatedWallet) {
           console.log("\nYour wallet and API key are saved. You're ready to build!");
+          console.log("\n" + "-".repeat(50));
+          console.log("IMPORTANT - BACK UP YOUR .env FILE:");
+          console.log("  - Your .env contains your wallet private key");
+          console.log("  - This wallet can hold real funds (FET, tokens)");
+          console.log("  - Back it up somewhere safe (password manager, secure drive)");
+          console.log("  - Never commit .env to git (add to .gitignore)");
+          console.log("  - Never share your .env file with anyone");
+          console.log("-".repeat(50));
           console.log("\nNEXT: npx agentlaunch my-first-agent");
         } else {
           console.log("\nYou can now use all agentlaunch commands.");

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-launch-mcp",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-launch-mcp",
-      "version": "2.3.7",
+      "version": "2.3.8",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
       },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-launch-mcp",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "MCP server for AgentLaunch - create AI agent tokens via Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/src/tools/auth.ts
+++ b/packages/mcp/src/tools/auth.ts
@@ -219,6 +219,14 @@ AGENTVERSE_API_KEY=${result.apiKey}
 1. Save the keys above to \`.env\`
 2. Run \`npx agentlaunch my-first-agent\` to create and deploy an agent
 
+## Important — Back Up Your .env
+
+Your \`.env\` file contains your wallet private key. This wallet can hold real funds.
+
+- **Back it up** somewhere safe (password manager, secure drive)
+- **Never commit** \`.env\` to git (add to \`.gitignore\`)
+- **Never share** your \`.env\` file with anyone
+
 The full keys are in the response data.`;
 
   return {


### PR DESCRIPTION
## Summary

Added clear security messaging for wallet generation - appropriate for agents (no hardware wallet references).

### CLI Output After `--generate`:
```
IMPORTANT - BACK UP YOUR .env FILE:
  - Your .env contains your wallet private key
  - This wallet can hold real funds (FET, tokens)
  - Back it up somewhere safe (password manager, secure drive)
  - Never commit .env to git (add to .gitignore)
  - Never share your .env file with anyone
```

### Changes
- CLI shows backup warning after wallet generation
- MCP tool includes backup reminder in markdown response  
- Docs updated with agent-appropriate security guidance

### Published
- `agentlaunch@1.2.11`
- `agent-launch-mcp@2.3.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)