### PR TITLE
feat: switch defaults to BSC Mainnet (chainId 56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ The remaining 3 require brief manual action. Run `npx agentlaunch optimize agent
 ### Phase 4: Tokenize
 
 ```bash
-npx agentlaunch tokenize --agent agent1q... --name "Price Oracle" --symbol DATA --chain 97
+npx agentlaunch tokenize --agent agent1q... --name "Price Oracle" --symbol DATA --chain 56
 ```
 
 Creates a pending token record via `POST /agents/tokenize`. Returns a handoff link.
@@ -343,12 +343,15 @@ These are baked into the smart contracts. Never change them:
 | Graduation Target | 30,000 FET -- auto DEX listing |
 | Trading Fee | 2% -- 100% to protocol treasury (no creator fee) |
 | Total Buy Supply | 800,000,000 tokens |
-| Default Chain | BSC (Testnet: 97, Mainnet: 56) |
+| Default Chain | BSC Mainnet (56) |
+| Contract | `0xeDecbC8E118288e1365Db14c9c2f3d51E91Cc247` |
 
 **Fee rule:** The 2% trading fee goes 100% to REVENUE_ACCOUNT (protocol treasury).
 There is NO creator fee split. The contract has no mechanism to send fees to creators.
 
-## Testnet Resources
+## Testnet Resources (for testing only — mainnet is the default)
+
+> **Note:** BSC Mainnet (chainId 56) is the default chain. Use BSC Testnet (chainId 97) only for development and testing.
 
 ### TFET Contract (BSC Testnet)
 ```

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ npm install && cp .env.example .env
 # Add your Agentverse API key: https://agentverse.ai/profile/api-keys
 ```
 
-### Get Testnet Tokens (BSC Testnet)
+### Get Testnet Tokens (BSC Testnet — for testing only)
 
-Before deploying, you need TFET and tBNB. Each wallet can claim up to **3 times** (200 TFET + 0.005 tBNB per claim). Three ways to claim:
+> **BSC Mainnet (chainId 56) is the default.** Use testnet only for development and testing.
+
+Before testing on testnet, you need TFET and tBNB. Each wallet can claim up to **3 times** (200 TFET + 0.005 tBNB per claim). Three ways to claim:
 
 **Option 1: Chat with @gift on Agentverse**
 
@@ -183,7 +185,7 @@ const token = await al.tokens.tokenize({
   symbol: 'PBOT',
   description: 'Monitors FET price',
   agentAddress: 'agent1q...',
-  chainId: 97,
+  chainId: 56, // BSC Mainnet (default) — use 97 for testnet
 });
 
 // Market data
@@ -274,7 +276,7 @@ Every token launches on a bonding curve: price starts low, rises with each purch
 | Graduation | 30,000 FET → auto DEX listing |
 | Trading Fee | 2% → protocol treasury |
 | Token Supply | 800,000,000 per token |
-| Default Chain | BSC (Testnet: 97, Mainnet: 56) |
+| Default Chain | BSC Mainnet (56) |
 
 ---
 
@@ -332,9 +334,9 @@ Full docs: [docs/agent-connect.md](docs/agent-connect.md)
 
 ## Get Started
 
-### Claiming Testnet Tokens
+### Claiming Testnet Tokens (for testing only)
 
-Need TFET or tBNB to deploy and test? Each wallet can claim up to **3 times** (200 TFET + 0.005 tBNB per claim).
+Need TFET or tBNB to test on BSC Testnet? Each wallet can claim up to **3 times** (200 TFET + 0.005 tBNB per claim). Mainnet is the default — testnet is for development only.
 
 **Chat with @gift on Agentverse** — [Open chat →](https://agentverse.ai/agents/details/agent1q2d0n5tp563wr0ugj9cmcqms9jfv5ks63xy5vg3evy5gy0z52e66xmeyyw9)
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -231,13 +231,13 @@ Claude uses the `deploy_to_agentverse` MCP tool. It will:
 Ask Claude:
 
 ```
-Tokenize my agent as $FTRK on BSC testnet
+Tokenize my agent as $FTRK on BSC mainnet
 ```
 
 Or use the CLI:
 
 ```bash
-npx agentlaunch tokenize --agent agent1q... --name "FET Tracker" --symbol FTRK --chain 97
+npx agentlaunch tokenize --agent agent1q... --name "FET Tracker" --symbol FTRK --chain 56
 ```
 
 Claude calls `create_token_record` and returns:
@@ -355,7 +355,7 @@ const result = await al.tokens.tokenize({
   agentAddress: 'agent1q...',
   name: 'My Agent',
   symbol: 'MAGNT',
-  chainId: 97,
+  chainId: 56,
 });
 
 console.log('Handoff link:', result.data.handoff_link);
@@ -372,7 +372,7 @@ const holders = await al.market.getHolders('0x...');
 curl -X POST https://agent-launch.ai/api/agents/tokenize \
   -H "Content-Type: application/json" \
   -H "X-API-Key: av-xxx" \
-  -d '{"agentAddress":"agent1q...","name":"My Agent","symbol":"MAGNT","description":"...","chainId":97}'
+  -d '{"agentAddress":"agent1q...","name":"My Agent","symbol":"MAGNT","description":"...","chainId":56}'
 
 # List tokens
 curl https://agent-launch.ai/api/tokens
@@ -486,7 +486,7 @@ Use with swarm-starter template for instant configuration:
 | Graduation | 30,000 FET raised triggers auto DEX listing |
 | Trading Fee | 2% on every trade, 100% to protocol treasury |
 | Token Supply | 800,000,000 per token |
-| Default Chain | BSC Testnet (97) / BSC Mainnet (56) |
+| Default Chain | BSC Mainnet (56) — use 97 for testnet |
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,9 +43,11 @@ Or override directly with `AGENT_LAUNCH_API_URL` and `AGENT_LAUNCH_FRONTEND_URL`
 
 ---
 
-## Get Testnet Tokens
+## Get Testnet Tokens (for testing only)
 
-Before you can deploy a token, you need TFET (testnet FET) and tBNB (testnet BNB for gas). The easiest way is to message **@gift** — the testnet faucet agent.
+> **BSC Mainnet (chainId 56) is the default.** Use testnet only for development and testing. To deploy on testnet, pass `chainId: 97` explicitly.
+
+Before you can test on testnet, you need TFET (testnet FET) and tBNB (testnet BNB for gas). The easiest way is to message **@gift** — the testnet faucet agent.
 
 ### Option 1: Message @gift (Recommended)
 
@@ -155,7 +157,7 @@ async function launchToken() {
     name: 'My Research Agent',
     symbol: 'MRA',
     description: 'Delivers on-demand research reports for the Fetch.ai ecosystem.',
-    chainId: 97, // BSC Testnet — use 56 for mainnet
+    chainId: 56, // BSC Mainnet (default) — use 97 for testnet
   });
 
   console.log('Token ID:', data.token_id);
@@ -210,7 +212,7 @@ agentlaunch tokenize \
   --agent agent1qf8xfhsc8hg4g5l0nhtj5hxxkyd46c64qxvpa3g3ha9rjmezq3s6xw9y7g \
   --name "My Research Agent" \
   --symbol MRA \
-  --chain 97
+  --chain 56
 ```
 
 Output:
@@ -300,7 +302,7 @@ Once configured, ask Claude Code (or Cursor with Claude):
 
 ```
 Create a token for my Agentverse agent at address agent1q...
-Name it "Alpha Research Bot", symbol ARB, on BSC testnet.
+Name it "Alpha Research Bot", symbol ARB, on BSC mainnet.
 ```
 
 Claude will call `create_and_tokenize` automatically and return:
@@ -377,7 +379,7 @@ agentlaunch sell 0xF7e2F77f... --amount 50000
 With `WALLET_PRIVATE_KEY` set in your MCP server env, ask Claude:
 
 ```
-Buy 10 FET worth of token 0xF7e2F77f... on BSC testnet
+Buy 10 FET worth of token 0xF7e2F77f... on BSC mainnet
 ```
 
 Claude will call the `buy_tokens` tool and return the transaction hash and details.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -236,7 +236,7 @@ agentlaunch tokenize \
   --name "My Research Agent" \
   --symbol RSRCH \
   --description "Delivers on-demand research" \
-  --chain 97 \
+  --chain 56 \
   --json
 ```
 
@@ -249,7 +249,7 @@ agentlaunch tokenize \
 | `--symbol <symbol>` | Ticker (2-11 chars) | required |
 | `--description <desc>` | Token description | - |
 | `--image <url>` | Token logo URL | - |
-| `--chain <chainId>` | 97 = BSC Testnet, 56 = BSC Mainnet | 97 |
+| `--chain <chainId>` | 56 = BSC Mainnet (default), 97 = BSC Testnet | 56 |
 | `--max-wallet <0\|1\|2>` | Max wallet size: 0=unlimited, 1=0.5% (5M tokens), 2=1% (10M tokens) | 0 |
 | `--initial-buy <amount>` | FET to spend buying tokens immediately after deploy (0-1000 FET) | 0 |
 | `--category <id>` | Category ID for the token | 1 |
@@ -284,7 +284,7 @@ agentlaunch buy 0xAbCd... --amount 10 --json
 | `--amount <fet>` | FET amount to spend | required |
 | `--dry-run` | Preview only (no transaction) | false |
 | `--slippage <pct>` | Slippage tolerance (%) | 5 |
-| `--chain <id>` | Chain ID (97=testnet, 56=mainnet) | 97 |
+| `--chain <id>` | Chain ID (56=mainnet, 97=testnet) | 56 |
 | `--json` | Output only JSON | false |
 
 ---
@@ -310,7 +310,7 @@ agentlaunch sell 0xAbCd... --amount 50000 --json
 |------|-------------|---------|
 | `--amount <tokens>` | Token amount to sell | required |
 | `--dry-run` | Preview only (no transaction) | false |
-| `--chain <id>` | Chain ID (97=testnet, 56=mainnet) | 97 |
+| `--chain <id>` | Chain ID (56=mainnet, 97=testnet) | 56 |
 | `--json` | Output only JSON | false |
 
 ---
@@ -398,7 +398,7 @@ agentlaunch pay 0xRecipient... 10 --token USDC --json
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--token <symbol>` | Token to pay with (FET, USDC) | FET |
-| `--chain <id>` | Chain ID | 97 |
+| `--chain <id>` | Chain ID (56=mainnet, 97=testnet) | 56 |
 | `--json` | Output only JSON | false |
 
 ---

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentlaunch",
-  "version": "1.2.11",
+  "version": "2.0.0",
   "description": "CLI for AgentLaunch — scaffold, deploy, and tokenize AI agents from the command line",
   "type": "module",
   "main": "dist/index.js",
@@ -24,8 +24,8 @@
   "license": "MIT",
   "dependencies": {
     "@cosmjs/crypto": "^0.32.0",
-    "agentlaunch-sdk": "^0.2.14",
-    "agentlaunch-templates": "0.4.11",
+    "agentlaunch-sdk": "^0.3.0",
+    "agentlaunch-templates": "^1.0.0",
     "bech32": "^2.0.0",
     "commander": "^12.0.0",
     "ethers": "^6.0.0",

--- a/packages/cli/src/commands/buy.ts
+++ b/packages/cli/src/commands/buy.ts
@@ -1,7 +1,7 @@
 /**
  * CLI: buy command
  *
- * agentlaunch buy <address> --amount <FET> [--slippage 5] [--chain 97] [--dry-run] [--json]
+ * agentlaunch buy <address> --amount <FET> [--slippage 5] [--chain 56] [--dry-run] [--json]
  *
  * Executes a buy on a bonding curve token contract, or previews the trade with --dry-run.
  */
@@ -16,7 +16,7 @@ export function registerBuyCommand(program: Command): void {
     .description("Buy tokens on a bonding curve (on-chain or dry-run preview)")
     .requiredOption("--amount <fet>", "Amount of FET to spend")
     .option("--slippage <percent>", "Slippage tolerance percentage", String(DEFAULT_SLIPPAGE_PERCENT))
-    .option("--chain <chainId>", "Chain ID (97=BSC Testnet, 56=BSC Mainnet)", "97")
+    .option("--chain <chainId>", "Chain ID (56=BSC Mainnet, 97=BSC Testnet)", "56")
     .option("--dry-run", "Preview the trade without executing (no wallet needed)")
     .option("--custodial", "Use server-side custodial wallet (requires AGENTVERSE_API_KEY)")
     .option("--agent <agentAddress>", "Agent address (agent1q...) to trade from agent's wallet (implies --custodial)")
@@ -55,11 +55,11 @@ export function registerBuyCommand(program: Command): void {
 
       // Validate chain
       const chainId = parseInt(options.chain, 10);
-      if (![97, 56].includes(chainId)) {
+      if (![56, 97].includes(chainId)) {
         if (options.json) {
-          console.log(JSON.stringify({ error: "Supported chains: 97 (BSC Testnet), 56 (BSC Mainnet)" }));
+          console.log(JSON.stringify({ error: "Supported chains: 56 (BSC Mainnet), 97 (BSC Testnet)" }));
         } else {
-          console.error("Error: Supported chains: 97 (BSC Testnet), 56 (BSC Mainnet)");
+          console.error("Error: Supported chains: 56 (BSC Mainnet), 97 (BSC Testnet)");
         }
         process.exit(1);
       }

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -44,7 +44,7 @@ export function registerConfigCommand(program: Command): void {
       const env = getEnvironment();
       const apiUrl = cfg.baseUrl ?? DEFAULT_BASE_URL;
       const frontendUrl = resolveFrontendUrl();
-      const chainId = process.env.CHAIN_ID || '97';
+      const chainId = process.env.CHAIN_ID || '56';
       const keyDisplay = cfg.apiKey ? maskKey(cfg.apiKey) : "(not set)";
 
       console.log("\n  AgentLaunch Configuration\n");

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -2,7 +2,7 @@
  * CLI-002 + CLI-006: create command
  *
  * agentlaunch create [--name "My Agent"] [--ticker MYAG] [--template custom]
- *                    [--description "..."] [--chain 97] [--deploy] [--tokenize] [--json]
+ *                    [--description "..."] [--chain 56] [--deploy] [--tokenize] [--json]
  *
  * Flagship one-command flow:
  *   1. Scaffold agent project (always) — via agentlaunch-templates
@@ -328,8 +328,8 @@ export function registerCreateCommand(program: Command): void {
     .option("--description <desc>", "Token description (max 500 chars)")
     .option(
       "--chain <chainId>",
-      "Chain ID: 97 (BSC testnet) or 56 (BSC mainnet) (default: 97)",
-      "97",
+      "Chain ID: 56 (BSC mainnet) or 97 (BSC testnet) (default: 56)",
+      "56",
     )
     .option("--deploy", "Deploy agent to Agentverse after scaffolding")
     .option("--tokenize", "Create token record on AgentLaunch after deploy")
@@ -943,7 +943,7 @@ AGENT_ADDRESS=${successful[0].address}
 
         const chainId = parseInt(options.chain, 10);
         if (![56, 97].includes(chainId)) {
-          errors.push("--chain must be 97 (BSC testnet) or 56 (BSC mainnet)");
+          errors.push("--chain must be 56 (BSC mainnet) or 97 (BSC testnet)");
         }
 
         if (errors.length > 0) {

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -34,7 +34,7 @@ const EMBEDDED_SKILL = `# AgentLaunch — Tokenize Any AI Agent
 curl -X POST https://agent-launch.ai/api/agents/tokenize \\
   -H "X-API-Key: YOUR_AGENTVERSE_API_KEY" \\
   -H "Content-Type: application/json" \\
-  -d '{"name": "MyBot", "symbol": "MYB", "description": "My AI agent", "chainId": 97}'
+  -d '{"name": "MyBot", "symbol": "MYB", "description": "My AI agent", "chainId": 56}'
 
 Response: { "success": true, "data": { "id": 42, "handoffLink": "https://agent-launch.ai/deploy/42" } }
 
@@ -64,7 +64,7 @@ ${EMBEDDED_MATRIX}
 - Graduation: 30,000 FET → auto DEX listing
 - Trading fee: 2% → 100% protocol treasury (no creator fee)
 - Bonding curve: 800M tradeable + 200M DEX reserve
-- Chain: BSC Testnet (97) / BSC Mainnet (56)
+- Chain: BSC Mainnet (56) / BSC Testnet (97)
 
 Full reference: https://agent-launch.ai/skill.md
 `;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -340,8 +340,8 @@ AGENT_LAUNCH_ENV=production
 # AGENT_LAUNCH_FRONTEND_URL=https://agent-launch.ai
 
 # ─── Chain ID ─────────────────────────────────────────────
-# 97 = BSC Testnet (default), 56 = BSC Mainnet
-CHAIN_ID=97
+# 56 = BSC Mainnet (default), 97 = BSC Testnet
+CHAIN_ID=56
 `;
 }
 
@@ -805,7 +805,7 @@ console.log(result.handoffLink); // https://agent-launch.ai/deploy/42
 curl -X POST https://agent-launch.ai/api/agents/tokenize \\
   -H "X-API-Key: YOUR_KEY" \\
   -H "Content-Type: application/json" \\
-  -d '{"agentAddress":"agent1q...","name":"My Agent","symbol":"MYAG","chainId":97}'
+  -d '{"agentAddress":"agent1q...","name":"My Agent","symbol":"MYAG","chainId":56}'
 \`\`\`
 
 ## Handoff Flow
@@ -828,7 +828,7 @@ Token is live on BSC Testnet
 |----------|---------|-------------|
 | AGENTVERSE_API_KEY | — | Auth for write endpoints |
 | AGENT_LAUNCH_ENV | production | Set to \`dev\` for dev URLs |
-| CHAIN_ID | 97 | 97=BSC Testnet, 56=BSC Mainnet |
+| CHAIN_ID | 56 | 56=BSC Mainnet, 97=BSC Testnet |
 | WALLET_PRIVATE_KEY | — | Only for autonomous on-chain trading |
 
 ## Next Steps
@@ -877,7 +877,7 @@ const result = await tokenize({
   name: 'My Agent',    // max 32 chars
   symbol: 'MYAG',      // 2–11 chars
   description: '...',  // max 500 chars
-  chainId: 97,         // 97=BSC Testnet, 56=BSC Mainnet
+  chainId: 56,         // 56=BSC Mainnet, 97=BSC Testnet
 });
 // result.handoffLink → https://agent-launch.ai/deploy/{id}
 // result.tokenId     → numeric ID for the handoff link
@@ -914,7 +914,7 @@ const preview = await calculateSell('0x...', '1000000');
 \`\`\`ts
 import { buyTokens } from 'agentlaunch-sdk';
 // Requires WALLET_PRIVATE_KEY env var
-const result = await buyTokens('0x...', '10', { chainId: 97, slippagePercent: 5 });
+const result = await buyTokens('0x...', '10', { chainId: 56, slippagePercent: 5 });
 // result.txHash, result.tokensReceived, result.fetSpent, result.fee
 \`\`\`
 
@@ -922,7 +922,7 @@ const result = await buyTokens('0x...', '10', { chainId: 97, slippagePercent: 5 
 \`\`\`ts
 import { sellTokens } from 'agentlaunch-sdk';
 // Requires WALLET_PRIVATE_KEY env var
-const result = await sellTokens('0x...', '1000000', { chainId: 97 });
+const result = await sellTokens('0x...', '1000000', { chainId: 56 });
 // result.txHash, result.fetReceived, result.tokensSold, result.fee
 \`\`\`
 
@@ -941,7 +941,7 @@ const deployed = await deployAgent({
 \`\`\`ts
 import { getMultiTokenBalances } from 'agentlaunch-sdk';
 // Requires WALLET_PRIVATE_KEY or pass address directly
-const balances = await getMultiTokenBalances('0x...', ['FET', 'BNB'], 97);
+const balances = await getMultiTokenBalances('0x...', ['FET', 'BNB'], 56);
 // { FET: '150.0000', BNB: '0.0012' }
 \`\`\`
 
@@ -951,7 +951,7 @@ const balances = await getMultiTokenBalances('0x...', ['FET', 'BNB'], 97);
 |----------|----------|-------------|
 | AGENTVERSE_API_KEY | Write ops | Auth for tokenize, deploy |
 | WALLET_PRIVATE_KEY | On-chain | Buy, sell, wallet balances |
-| CHAIN_ID | No | Default: 97 (BSC Testnet) |
+| CHAIN_ID | No | Default: 56 (BSC Mainnet) |
 | AGENT_LAUNCH_ENV | No | \`dev\` to use dev URLs |
 | AGENT_LAUNCH_API_URL | No | Override API base URL |
 | AGENT_LAUNCH_FRONTEND_URL | No | Override frontend URL |
@@ -996,7 +996,7 @@ Create a token record and get a handoff link.
 \`\`\`bash
 agentlaunch tokenize --agent agent1q... --name "Token" --symbol TKN
 agentlaunch tokenize --agent agent1q... --name "Token" --symbol TKN \\
-  --description "My token" --chain 97 --json
+  --description "My token" --chain 56 --json
 \`\`\`
 
 ### list
@@ -1200,7 +1200,7 @@ const result = await tokenize({
   name: 'My Research Agent',
   symbol: 'MRA',
   description: 'AI-powered research assistant',
-  chainId: 97,
+  chainId: 56,
 });
 
 // Send to human via any channel

--- a/packages/cli/src/commands/pay.ts
+++ b/packages/cli/src/commands/pay.ts
@@ -1,7 +1,7 @@
 /**
  * CLI: pay and invoice commands
  *
- * agentlaunch pay <agent> <amount> --token USDC [--chain 97] [--json]
+ * agentlaunch pay <agent> <amount> --token USDC [--chain 56] [--json]
  * agentlaunch invoice create --agent <addr> --payer <addr> --service <svc> --amount <n> [--token FET] [--json]
  * agentlaunch invoice list --agent <addr> [--status pending] [--json]
  */
@@ -21,7 +21,7 @@ export function registerPayCommand(program: Command): void {
     .command("pay <to> <amount>")
     .description("Pay an agent or wallet in any supported token")
     .option("--token <symbol>", "Token symbol (default: FET)", "FET")
-    .option("--chain <chainId>", "Chain ID", "97")
+    .option("--chain <chainId>", "Chain ID", "56")
     .option("-y, --yes", "Skip confirmation prompt")
     .option("--json", "Output raw JSON")
     .action(async (to: string, amount: string, options: { token: string; chain: string; yes?: boolean; json?: boolean }) => {
@@ -109,7 +109,7 @@ export function registerPayCommand(program: Command): void {
     .requiredOption("--service <name>", "Service being invoiced")
     .requiredOption("--amount <amount>", "Invoice amount (decimal string)")
     .option("--token <symbol>", "Token symbol (default: FET)", "FET")
-    .option("--chain <chainId>", "Chain ID", "97")
+    .option("--chain <chainId>", "Chain ID", "56")
     .option("--json", "Output raw JSON")
     .action(async (options: {
       agent: string;

--- a/packages/cli/src/commands/sell.ts
+++ b/packages/cli/src/commands/sell.ts
@@ -1,7 +1,7 @@
 /**
  * CLI: sell command
  *
- * agentlaunch sell <address> --amount <tokens> [--chain 97] [--dry-run] [--json]
+ * agentlaunch sell <address> --amount <tokens> [--chain 56] [--dry-run] [--json]
  *
  * Executes a sell on a bonding curve token contract, or previews the trade with --dry-run.
  */
@@ -15,7 +15,7 @@ export function registerSellCommand(program: Command): void {
     .command("sell <address>")
     .description("Sell tokens on a bonding curve (on-chain or dry-run preview)")
     .requiredOption("--amount <tokens>", "Amount of tokens to sell")
-    .option("--chain <chainId>", "Chain ID (97=BSC Testnet, 56=BSC Mainnet)", "97")
+    .option("--chain <chainId>", "Chain ID (56=BSC Mainnet, 97=BSC Testnet)", "56")
     .option("--dry-run", "Preview the trade without executing (no wallet needed)")
     .option("--custodial", "Use server-side custodial wallet (requires AGENTVERSE_API_KEY)")
     .option("--agent <agentAddress>", "Agent address (agent1q...) to trade from agent's wallet (implies --custodial)")
@@ -55,11 +55,11 @@ export function registerSellCommand(program: Command): void {
 
       // Validate chain
       const chainId = parseInt(options.chain, 10);
-      if (![97, 56].includes(chainId)) {
+      if (![56, 97].includes(chainId)) {
         if (options.json) {
-          console.log(JSON.stringify({ error: "Supported chains: 97 (BSC Testnet), 56 (BSC Mainnet)" }));
+          console.log(JSON.stringify({ error: "Supported chains: 56 (BSC Mainnet), 97 (BSC Testnet)" }));
         } else {
-          console.error("Error: Supported chains: 97 (BSC Testnet), 56 (BSC Mainnet)");
+          console.error("Error: Supported chains: 56 (BSC Mainnet), 97 (BSC Testnet)");
         }
         process.exit(1);
       }

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -110,6 +110,6 @@ Platform Constants:
   Graduation:   30,000 FET → auto DEX listing
   Trading fee:  2% → 100% protocol treasury
   Bonding curve: 800M tradeable + 200M DEX reserve
-  Chain:        BSC Testnet (97) / BSC Mainnet (56)`);
+  Chain:        BSC Mainnet (56) / BSC Testnet (97)`);
     });
 }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -89,7 +89,7 @@ export function registerStatusCommand(program: Command): void {
       const holders =
         token.holders ?? token.holderCount ?? token.holder_count ?? 0;
       const progress = formatProgress(token.progress);
-      const chainId = token.chainId ?? token.chain_id ?? 97;
+      const chainId = token.chainId ?? token.chain_id ?? 56;
       const chainName =
         chainId === 56
           ? "BSC Mainnet"

--- a/packages/cli/src/commands/tokenize.ts
+++ b/packages/cli/src/commands/tokenize.ts
@@ -62,8 +62,8 @@ export function registerTokenizeCommand(program: Command): void {
     .option("--image <url>", "URL of the token logo image")
     .option(
       "--chain <chainId>",
-      "Chain ID: 97 (BSC testnet) or 56 (BSC mainnet)",
-      "97",
+      "Chain ID: 56 (BSC mainnet) or 97 (BSC testnet)",
+      "56",
     )
     .option(
       "--max-wallet <value>",
@@ -133,12 +133,12 @@ export function registerTokenizeCommand(program: Command): void {
           if (isJson) {
             console.log(
               JSON.stringify({
-                error: "--chain must be 97 (BSC testnet) or 56 (BSC mainnet)",
+                error: "--chain must be 56 (BSC mainnet) or 97 (BSC testnet)",
               }),
             );
           } else {
             console.error(
-              "Error: --chain must be 97 (BSC testnet) or 56 (BSC mainnet)",
+              "Error: --chain must be 56 (BSC mainnet) or 97 (BSC testnet)",
             );
           }
           process.exit(1);

--- a/packages/cli/src/commands/wallet.ts
+++ b/packages/cli/src/commands/wallet.ts
@@ -1,10 +1,10 @@
 /**
  * CLI: wallet command group
  *
- * agentlaunch wallet balances [--token USDC] [--chain 97] [--json]
- * agentlaunch wallet delegate <token> <amount> --spender <address> [--chain 97] [--json]
- * agentlaunch wallet allowance <token> --owner <address> --spender <address> [--chain 97] [--json]
- * agentlaunch wallet send <token> <to> <amount> [--chain 97] [--json]
+ * agentlaunch wallet balances [--token USDC] [--chain 56] [--json]
+ * agentlaunch wallet delegate <token> <amount> --spender <address> [--chain 56] [--json]
+ * agentlaunch wallet allowance <token> --owner <address> --spender <address> [--chain 56] [--json]
+ * agentlaunch wallet send <token> <to> <amount> [--chain 56] [--json]
  */
 
 import { Command } from "commander";
@@ -53,7 +53,7 @@ async function runBalances(options: { address?: string; token?: string; chain: s
       console.log(JSON.stringify({ wallet: walletAddr, chainId, balances }));
     } else {
       console.log(`\n  Wallet: ${walletAddr}`);
-      console.log(`  Chain:  ${chainId === 97 ? "BSC Testnet" : chainId === 56 ? "BSC Mainnet" : `Chain ${chainId}`}\n`);
+      console.log(`  Chain:  ${chainId === 56 ? "BSC Mainnet" : chainId === 97 ? "BSC Testnet" : `Chain ${chainId}`}\n`);
       for (const [symbol, balance] of Object.entries(balances)) {
         const bal = parseFloat(balance);
         console.log(`  ${symbol.padEnd(8)} ${bal.toFixed(4)}`);
@@ -78,7 +78,7 @@ export function registerWalletCommand(program: Command): void {
     .description("Multi-token wallet operations: balances, delegation, transfers")
     .option("--address <address>", "Wallet address to query (read-only, no private key needed)")
     .option("--token <symbols>", "Comma-separated token symbols (default: all known)")
-    .option("--chain <chainId>", "Chain ID (97=BSC Testnet, 56=BSC Mainnet)", "97")
+    .option("--chain <chainId>", "Chain ID (56=BSC Mainnet, 97=BSC Testnet)", "56")
     .action(async (options: { address?: string; token?: string; chain: string; json?: boolean }) => {
       // Default: run balances when no subcommand is given
       await runBalances(options);
@@ -90,7 +90,7 @@ export function registerWalletCommand(program: Command): void {
     .description("Show wallet balances for BNB, FET, USDC, and custom tokens")
     .option("--address <address>", "Wallet address to query (read-only, no private key needed)")
     .option("--token <symbols>", "Comma-separated token symbols (default: all known)")
-    .option("--chain <chainId>", "Chain ID (97=BSC Testnet, 56=BSC Mainnet)", "97")
+    .option("--chain <chainId>", "Chain ID (56=BSC Mainnet, 97=BSC Testnet)", "56")
     .option("--json", "Output raw JSON")
     .action(async (options: { address?: string; token?: string; chain: string; json?: boolean }) => {
       await runBalances(options);
@@ -101,7 +101,7 @@ export function registerWalletCommand(program: Command): void {
     .command("delegate <token> <amount>")
     .description("Generate a delegation handoff link for ERC-20 spending approval")
     .requiredOption("--spender <address>", "Agent wallet address to authorize (0x...)")
-    .option("--chain <chainId>", "Chain ID", "97")
+    .option("--chain <chainId>", "Chain ID", "56")
     .option("--json", "Output raw JSON")
     .action(async (token: string, amount: string, options: { spender: string; chain: string; json?: boolean }) => {
       const chainId = parseInt(options.chain, 10);
@@ -139,7 +139,7 @@ export function registerWalletCommand(program: Command): void {
     .description("Check ERC-20 spending limit (allowance)")
     .requiredOption("--owner <address>", "Token owner address (0x...)")
     .requiredOption("--spender <address>", "Approved spender address (0x...)")
-    .option("--chain <chainId>", "Chain ID", "97")
+    .option("--chain <chainId>", "Chain ID", "56")
     .option("--json", "Output raw JSON")
     .action(async (token: string, options: { owner: string; spender: string; chain: string; json?: boolean }) => {
       const chainId = parseInt(options.chain, 10);
@@ -186,7 +186,7 @@ export function registerWalletCommand(program: Command): void {
   wallet
     .command("send <token> <to> <amount>")
     .description("Send ERC-20 tokens to a recipient")
-    .option("--chain <chainId>", "Chain ID", "97")
+    .option("--chain <chainId>", "Chain ID", "56")
     .option("-y, --yes", "Skip confirmation prompt")
     .option("--json", "Output raw JSON")
     .action(async (token: string, to: string, amount: string, options: { chain: string; yes?: boolean; json?: boolean }) => {
@@ -262,7 +262,7 @@ export function registerWalletCommand(program: Command): void {
   wallet
     .command("custodial")
     .description("Show server-managed custodial wallet (user wallet by default, or a specific agent's wallet)")
-    .option("--chain <chainId>", "Chain ID (97=BSC Testnet, 56=BSC Mainnet)", "97")
+    .option("--chain <chainId>", "Chain ID (56=BSC Mainnet, 97=BSC Testnet)", "56")
     .option("--agent <address>", "Agent address (agent1q...) to get that agent's wallet instead of your user wallet")
     .option("--json", "Output raw JSON")
     .action(async (options: { chain: string; agent?: string; json?: boolean }) => {
@@ -274,7 +274,7 @@ export function registerWalletCommand(program: Command): void {
         if (options.json) {
           console.log(JSON.stringify(info));
         } else {
-          const chainLabel = chainId === 97 ? "BSC Testnet" : chainId === 56 ? "BSC Mainnet" : `Chain ${chainId}`;
+          const chainLabel = chainId === 56 ? "BSC Mainnet" : chainId === 97 ? "BSC Testnet" : `Chain ${chainId}`;
           const gasSymbol = chainId === 1 || chainId === 11155111 ? "ETH" : "BNB";
           const explorerBase = chainId === 56 ? "https://bscscan.com" : "https://testnet.bscscan.com";
           const walletType = options.agent ? "AGENT WALLET" : "USER WALLET";

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -230,7 +230,7 @@ After editing the config, restart Claude Code / Claude Desktop.
   "tokenSymbol": "USDC",
   "to": "0xRecipient...",
   "amount": "10",
-  "chainId": 97
+  "chainId": 56
 }
 ```
 
@@ -244,7 +244,7 @@ After editing the config, restart Claude Code / Claude Desktop.
   "tokenSymbol": "FET",
   "owner": "0xOwner...",
   "spender": "0xAgent...",
-  "chainId": 97
+  "chainId": 56
 }
 ```
 
@@ -258,7 +258,7 @@ After editing the config, restart Claude Code / Claude Desktop.
   "tokenSymbol": "FET",
   "amount": "100",
   "agentAddress": "0xAgent...",
-  "chainId": 97
+  "chainId": 56
 }
 ```
 
@@ -287,7 +287,7 @@ After editing the config, restart Claude Code / Claude Desktop.
 {
   "walletAddress": "0x...",
   "tokenSymbols": ["FET", "USDC"],
-  "chainId": 97
+  "chainId": 56
 }
 ```
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-launch-mcp",
-  "version": "2.3.8",
+  "version": "3.0.0",
   "description": "MCP server for AgentLaunch - create AI agent tokens via Claude Code",
   "type": "module",
   "main": "dist/index.js",
@@ -23,8 +23,8 @@
   "dependencies": {
     "@cosmjs/crypto": "^0.32.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
-    "agentlaunch-sdk": "^0.2.11",
-    "agentlaunch-templates": "0.4.11",
+    "agentlaunch-sdk": "^0.3.0",
+    "agentlaunch-templates": "^1.0.0",
     "bech32": "^2.0.0",
     "dotenv": "^17.3.1",
     "ethers": "^6.0.0"

--- a/packages/mcp/src/__tests__/lifecycle.test.ts
+++ b/packages/mcp/src/__tests__/lifecycle.test.ts
@@ -123,7 +123,7 @@ describe('MCP-HO01: create_token_record', () => {
       const body = JSON.parse(init?.body as string);
       assert.equal(body.name, 'TestToken');
       assert.equal(body.symbol, 'TST');
-      assert.equal(body.chainId, 97);
+      assert.equal(body.chainId, 56);
       return Promise.resolve(makeResponse(apiResponse));
     });
 

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -112,11 +112,13 @@ describe('MCP Server Infrastructure', () => {
 
 describe('Discovery Tools', () => {
   it('MCP-D01: list_tokens returns token list', async () => {
-    const mockBody = { items: [{ id: 1, name: 'Test' }], total: 1 };
-    restoreFn = installFetchMock(() => Promise.resolve(makeResponse(mockBody)));
+    // The SDK's listTokens() expects the API envelope: { success, data, meta }
+    const mockApiResponse = { success: true, data: [{ id: 1, name: 'Test' }], meta: { page: 1, limit: 20, total: 1, totalPages: 1 } };
+    restoreFn = installFetchMock(() => Promise.resolve(makeResponse(mockApiResponse)));
 
     const { _markdown, ...result } = await discoveryHandlers.list_tokens({}) as any;
-    assert.deepEqual(result, mockBody);
+    // SDK transforms to { tokens, total }
+    assert.deepEqual(result, { tokens: [{ id: 1, name: 'Test' }], total: 1 });
     assert.ok(typeof _markdown === 'string', 'should include _markdown string');
   });
 
@@ -124,7 +126,7 @@ describe('Discovery Tools', () => {
     let capturedUrl = '';
     restoreFn = installFetchMock((url) => {
       capturedUrl = String(url);
-      return Promise.resolve(makeResponse({ items: [], total: 0 }));
+      return Promise.resolve(makeResponse({ success: true, data: [], meta: { page: 1, limit: 20, total: 0, totalPages: 0 } }));
     });
 
     await discoveryHandlers.list_tokens({ status: 'bonding' });
@@ -138,7 +140,7 @@ describe('Discovery Tools', () => {
     let capturedUrl = '';
     restoreFn = installFetchMock((url) => {
       capturedUrl = String(url);
-      return Promise.resolve(makeResponse({ items: [], total: 0 }));
+      return Promise.resolve(makeResponse({ success: true, data: [], meta: { page: 1, limit: 20, total: 0, totalPages: 0 } }));
     });
 
     await discoveryHandlers.list_tokens({ chainId: 97 });

--- a/packages/mcp/src/__tests__/trading-server.test.ts
+++ b/packages/mcp/src/__tests__/trading-server.test.ts
@@ -202,6 +202,7 @@ describe('MCP server registration', () => {
     'update_connection',
     'wallet_auth',
     'check_auth',
+    'generate_wallet',
   ];
 
   // MCP-S02

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -91,7 +91,7 @@ export const TOOLS = [
         chainId: {
           type: "number",
           description:
-            "Filter by chain (97=BSC testnet, 56=BSC mainnet)",
+            "Filter by chain (56=BSC mainnet, 97=BSC testnet)",
         },
         sort: {
           type: "string",
@@ -211,7 +211,7 @@ export const TOOLS = [
         },
         chainId: {
           type: "number",
-          description: "Chain ID (default: 97)",
+          description: "Chain ID (default: 56)",
         },
       },
       required: ["agentAddress", "name", "symbol", "description", "category"],
@@ -386,7 +386,7 @@ export const TOOLS = [
         chainId: {
           type: "number",
           description:
-            "Chain ID (default: 97 = BSC testnet, 56 = BSC mainnet).",
+            "Chain ID (default: 56 = BSC mainnet, 97 = BSC testnet).",
         },
         maxWalletAmount: {
           type: "number",
@@ -531,7 +531,7 @@ export const TOOLS = [
         chainId: {
           type: "number",
           description:
-            "Chain ID (97=BSC Testnet, 56=BSC Mainnet). Default: 97",
+            "Chain ID (56=BSC Mainnet, 97=BSC Testnet). Default: 56",
         },
         slippagePercent: {
           type: "number",
@@ -565,7 +565,7 @@ export const TOOLS = [
         chainId: {
           type: "number",
           description:
-            "Chain ID (97=BSC Testnet, 56=BSC Mainnet). Default: 97",
+            "Chain ID (56=BSC Mainnet, 97=BSC Testnet). Default: 56",
         },
         dryRun: {
           type: "boolean",
@@ -590,7 +590,7 @@ export const TOOLS = [
         chainId: {
           type: "number",
           description:
-            "Chain ID (97=BSC Testnet, 56=BSC Mainnet). Default: 97",
+            "Chain ID (56=BSC Mainnet, 97=BSC Testnet). Default: 56",
         },
       },
       required: ["address"],
@@ -607,7 +607,7 @@ export const TOOLS = [
         chainId: {
           type: "number",
           description:
-            "Chain ID to query balances on (97=BSC Testnet, 56=BSC Mainnet). Default: 97",
+            "Chain ID to query balances on (56=BSC Mainnet, 97=BSC Testnet). Default: 56",
         },
         agentAddress: {
           type: "string",
@@ -736,7 +736,7 @@ export const TOOLS = [
         },
         chainId: {
           type: "number",
-          description: "Chain ID (97=BSC Testnet, 56=BSC Mainnet). Default: 97",
+          description: "Chain ID (56=BSC Mainnet, 97=BSC Testnet). Default: 56",
         },
       },
       required: ["tokenSymbol", "to", "amount"],
@@ -763,7 +763,7 @@ export const TOOLS = [
         },
         chainId: {
           type: "number",
-          description: "Chain ID. Default: 97",
+          description: "Chain ID. Default: 56",
         },
       },
       required: ["tokenSymbol", "owner", "spender"],
@@ -790,7 +790,7 @@ export const TOOLS = [
         },
         chainId: {
           type: "number",
-          description: "Chain ID. Default: 97",
+          description: "Chain ID. Default: 56",
         },
       },
       required: ["tokenSymbol", "amount", "agentAddress"],
@@ -861,7 +861,7 @@ export const TOOLS = [
         },
         chainId: {
           type: "number",
-          description: "Chain ID. Default: 97",
+          description: "Chain ID. Default: 56",
         },
       },
       required: ["agentAddress", "invoiceId", "payer", "service", "amount"],
@@ -1002,7 +1002,7 @@ export const TOOLS = [
         },
         chainId: {
           type: "number",
-          description: "Chain ID (97=BSC Testnet, 56=BSC Mainnet). Default: 97",
+          description: "Chain ID (56=BSC Mainnet, 97=BSC Testnet). Default: 56",
         },
       },
       required: ["walletAddress"],

--- a/packages/mcp/src/tools/custodial.ts
+++ b/packages/mcp/src/tools/custodial.ts
@@ -56,7 +56,7 @@ export async function getAgentWalletTool(args: {
   chainId?: number;
   agentAddress?: string;
 }): Promise<WalletInfoResponse & { _markdown: string }> {
-  const chainId = args.chainId ?? 97;
+  const chainId = args.chainId ?? 56;
 
   const info = await getWallet(chainId, args.agentAddress);
 

--- a/packages/mcp/src/tools/handoff.ts
+++ b/packages/mcp/src/tools/handoff.ts
@@ -113,7 +113,7 @@ export async function createTokenRecord(args: {
     category: args.category,
     agentAddress: args.agentAddress,
     logo: args.logo,
-    chainId: args.chainId ?? 97,
+    chainId: args.chainId ?? 56,
   });
 
   // Unwrap data envelope if present
@@ -132,7 +132,7 @@ export async function createTokenRecord(args: {
 | Token ID | ${tokenId ?? '—'} |
 | Name | ${args.name} |
 | Symbol | ${args.symbol} |
-| Chain | ${args.chainId ?? 97} |
+| Chain | ${args.chainId ?? 56} |
 | Deploy Fee | 120 FET |
 
 ## Next Steps

--- a/packages/mcp/src/tools/payments.ts
+++ b/packages/mcp/src/tools/payments.ts
@@ -45,7 +45,7 @@ export async function multiTokenPaymentTool(args: {
   amount: string;
   chainId?: number;
 }): Promise<{ txHash: string; blockNumber: number; token: string; amount: string; to: string; _markdown: string }> {
-  const chainId = args.chainId ?? 97;
+  const chainId = args.chainId ?? 56;
   const token = getPaymentToken(args.tokenSymbol, chainId);
   if (!token) {
     throw new Error(`Unknown token: ${args.tokenSymbol} on chain ${chainId}. Known: FET, USDC.`);
@@ -115,7 +115,7 @@ export async function checkSpendingLimitTool(args: {
   spender: string;
   chainId?: number;
 }): Promise<SpendingLimit & { _markdown: string }> {
-  const chainId = args.chainId ?? 97;
+  const chainId = args.chainId ?? 56;
   const token = getPaymentToken(args.tokenSymbol, chainId);
   if (!token) {
     throw new Error(`Unknown token: ${args.tokenSymbol} on chain ${chainId}`);
@@ -249,7 +249,7 @@ export async function createInvoiceTool(args: {
   tokenSymbol?: string;
   chainId?: number;
 }): Promise<{ template: string; _markdown: string }> {
-  const chainId = args.chainId ?? 97;
+  const chainId = args.chainId ?? 56;
   const tokenSymbol = args.tokenSymbol ?? 'FET';
   const token = getPaymentToken(tokenSymbol, chainId);
   if (!token) {
@@ -350,7 +350,7 @@ export async function getMultiTokenBalancesTool(args: {
     .map(([token, amount]) => `| ${token} | ${amount} |`)
     .join('\n');
 
-  const chainId = args.chainId ?? 97;
+  const chainId = args.chainId ?? 56;
 
   const _markdown = `# Balances
 

--- a/packages/mcp/src/tools/tokenize.ts
+++ b/packages/mcp/src/tools/tokenize.ts
@@ -95,7 +95,7 @@ export async function createAndTokenize(args: {
   const templateKey = args.template ?? 'research';
   const templateName = TYPE_TO_TEMPLATE[templateKey] ?? 'custom';
   const ticker = args.ticker ?? deriveTicker(args.name);
-  const chainId = args.chainId ?? 97;
+  const chainId = args.chainId ?? 56;
 
   // Step 1: Scaffold agent code from template
   const generated = generateFromTemplate(templateName, {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -47,7 +47,7 @@ import { tokenize, generateDeployLink } from 'agentlaunch-sdk';
 const { data } = await tokenize({
   agentAddress: 'agent1qf8xfhsc8hg4g5l0nhtj...',
   name: 'My Agent Token',
-  chainId: 97, // BSC Testnet
+  chainId: 56, // BSC Mainnet (default) — use 97 for testnet
 });
 
 // 2. Generate a deploy link for a human to complete on-chain deployment
@@ -92,7 +92,7 @@ const { data } = await tokenize({
   symbol: 'MAT',                                     // optional — derived from name
   description: 'An AI agent that...',               // optional
   image: 'https://example.com/logo.png',             // optional — 'auto' for placeholder
-  chainId: 97,                                       // optional — default: 11155111 (Sepolia)
+  chainId: 56,                                        // optional — default: 56 (BSC Mainnet)
   maxWalletAmount: 1,                                // optional — 0=unlimited, 1=0.5%, 2=1%
   initialBuyAmount: '50',                            // optional — FET to buy on deploy (max 1000)
   category: 3,                                       // optional — see /tokens/categories
@@ -146,7 +146,7 @@ const { tokens, total } = await listTokens({
   search: 'agent',
   sortBy: 'market_cap',
   sortOrder: 'DESC',
-  chainId: 97,
+  chainId: 56,
 });
 ```
 
@@ -164,7 +164,7 @@ Buy tokens on the bonding curve. Handles FET approval automatically.
 import { buyTokens } from 'agentlaunch-sdk';
 
 const result = await buyTokens('0xAbCd...', '10', {
-  chainId: 97,        // BSC Testnet (default)
+  chainId: 56,        // BSC Mainnet (default) — use 97 for testnet
   slippagePercent: 5,  // 5% slippage tolerance (default)
 });
 
@@ -204,7 +204,7 @@ console.log(balances.wallet);        // '0x1234...'
 console.log(balances.bnb);           // '0.05'
 console.log(balances.fet);           // '150.0'
 console.log(balances.token);         // '500000.0'
-console.log(balances.chainId);       // 97
+console.log(balances.chainId);       // 56
 ```
 
 #### `getERC20Balance(tokenAddress, walletAddress, config?)`
@@ -270,7 +270,7 @@ const { txHash, blockNumber } = await transferFromERC20(
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `privateKey` | `string` | `WALLET_PRIVATE_KEY` env | Wallet private key |
-| `chainId` | `number` | `97` | BSC Testnet (97) or Mainnet (56) |
+| `chainId` | `number` | `56` | BSC Mainnet (56) or Testnet (97) |
 | `slippagePercent` | `number` | `5` | Slippage tolerance (0-100) |
 | `client` | `AgentLaunchClient` | — | For API calls (calculateBuy/Sell) |
 
@@ -295,14 +295,14 @@ Registry of well-known token addresses per chain.
 import { KNOWN_TOKENS, getPaymentToken, getTokensForChain } from 'agentlaunch-sdk';
 
 // Look up a token by symbol
-const fet = getPaymentToken('FET', 97);
-// { symbol: 'FET', contractAddress: '0x304d...', decimals: 18, chainId: 97, isStablecoin: false }
+const fet = getPaymentToken('FET', 56);
+// { symbol: 'FET', contractAddress: '0xBd5d...', decimals: 18, chainId: 56, isStablecoin: false }
 
-const usdc = getPaymentToken('USDC', 97);
-// { symbol: 'USDC', contractAddress: '0x6454...', decimals: 18, chainId: 97, isStablecoin: true }
+const usdc = getPaymentToken('USDC', 56);
+// { symbol: 'USDC', contractAddress: '0x8AC7...', decimals: 18, chainId: 56, isStablecoin: true }
 
 // List all tokens on a chain
-const bscTestnetTokens = getTokensForChain(97); // [FET, USDC]
+const bscMainnetTokens = getTokensForChain(56); // [FET, USDC]
 ```
 
 **Known token addresses:**
@@ -322,9 +322,9 @@ Get the balance of any ERC-20 token for a wallet.
 import { getTokenBalance } from 'agentlaunch-sdk';
 
 const balance = await getTokenBalance(
-  '0x304ddf3eE068c53514f782e2341B71A80c8aE3C7', // FET
+  '0xBd5df99ABe0E2b1e86BE5eC0039d1e24de28Fe87', // FET on BSC Mainnet
   '0xMyWallet...',
-  97,
+  56,
 );
 console.log(balance); // '150.0'
 ```
@@ -342,7 +342,7 @@ console.log(balances);
 // { BNB: '0.05', FET: '150.0', USDC: '25.0' }
 
 // Specific tokens only
-const fetOnly = await getMultiTokenBalances('0xMyWallet...', ['FET'], 97);
+const fetOnly = await getMultiTokenBalances('0xMyWallet...', ['FET'], 56);
 // { BNB: '0.05', FET: '150.0' }
 ```
 
@@ -354,11 +354,11 @@ Transfer any ERC-20 token to a recipient.
 import { transferToken } from 'agentlaunch-sdk';
 
 const { txHash, blockNumber } = await transferToken(
-  '0x64544969ed7EBf5f083679233325356EbE738930', // USDC
+  '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d', // USDC on BSC Mainnet
   '0xRecipient...',
   '10',
   process.env.WALLET_PRIVATE_KEY!,
-  97,
+  56,
 );
 ```
 
@@ -380,7 +380,7 @@ const invoice = await createInvoice('agent1q...', {
   issuer: 'agent1q...',
   payer: '0xCustomer...',
   service: 'blog_post',
-  amount: { amount: '0.01', token: { symbol: 'FET', contractAddress: '0x304d...', decimals: 18, chainId: 97, isStablecoin: false } },
+  amount: { amount: '0.01', token: { symbol: 'FET', contractAddress: '0xBd5d...', decimals: 18, chainId: 56, isStablecoin: false } },
 });
 
 console.log(invoice.status);    // 'pending'
@@ -442,10 +442,10 @@ Check the on-chain ERC-20 allowance for a spender.
 import { checkAllowance } from 'agentlaunch-sdk';
 
 const limit = await checkAllowance(
-  '0x304ddf3eE068c53514f782e2341B71A80c8aE3C7', // FET
+  '0xBd5df99ABe0E2b1e86BE5eC0039d1e24de28Fe87', // FET on BSC Mainnet
   '0xOwner...',
   '0xAgent...',
-  97,
+  56,
 );
 
 console.log(limit.remaining); // '100.0'
@@ -475,7 +475,7 @@ Generate a handoff link for a human to approve a spending limit.
 import { createSpendingLimitHandoff } from 'agentlaunch-sdk';
 
 const link = createSpendingLimitHandoff(
-  { tokenSymbol: 'FET', amount: '100', chainId: 97 },
+  { tokenSymbol: 'FET', amount: '100', chainId: 56 },
   '0xAgentWallet...',
 );
 // https://agent-launch.ai/delegate?token=0x304d...&spender=0xAgent...&amount=100
@@ -491,7 +491,7 @@ import { recordDelegation } from 'agentlaunch-sdk';
 await recordDelegation('agent1q...', {
   owner: '0xOwner...',
   spender: '0xAgent...',
-  token: { symbol: 'FET', contractAddress: '0x304d...', decimals: 18, chainId: 97, isStablecoin: false },
+  token: { symbol: 'FET', contractAddress: '0xBd5d...', decimals: 18, chainId: 56, isStablecoin: false },
   maxAmount: '100',
   spent: '0',
   remaining: '100',
@@ -924,7 +924,7 @@ const sellResult = await al.onchain.sell('0xAbCd...', '50000');
 const balances = await al.onchain.getBalances('0xAbCd...');
 
 // Multi-token payments
-const fetToken = al.payments.getToken('FET', 97);
+const fetToken = al.payments.getToken('FET', 56);
 const multiBalances = await al.payments.getMultiTokenBalances('0xWallet...');
 const inv = await al.payments.createInvoice('agent1q...', {
   id: 'inv-001', issuer: 'agent1q...', payer: '0x...', service: 'api',
@@ -1019,7 +1019,7 @@ On-chain functions throw standard `Error` with descriptive messages:
 - **Total Buy Tokens:** 800,000,000
 - **Deployment Fee:** 120 FET (read dynamically from contract, can change via governance)
 - **Trading Fee:** 2% per transaction — goes 100% to the protocol treasury. There is no creator fee.
-- **Default Chain:** BSC (mainnet: 56, testnet: 97)
+- **Default Chain:** BSC Mainnet (56) — use 97 for testnet
 
 ## Cross-References
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentlaunch-sdk",
-  "version": "0.2.15",
+  "version": "0.3.0",
   "description": "TypeScript SDK for the AgentLaunch platform — create AI agent tokens, query market data, and generate handoff links",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/src/__tests__/delegation.test.ts
+++ b/packages/sdk/src/__tests__/delegation.test.ts
@@ -171,7 +171,7 @@ describe('Delegation — handoff link generation', () => {
     );
   });
 
-  it('createSpendingLimitHandoff defaults to chain 97', async () => {
+  it('createSpendingLimitHandoff defaults to chain 56', async () => {
     const { createSpendingLimitHandoff } = await import('../delegation.js');
     const link = createSpendingLimitHandoff(
       { tokenSymbol: 'FET', amount: '50' },

--- a/packages/sdk/src/__tests__/fluent.test.ts
+++ b/packages/sdk/src/__tests__/fluent.test.ts
@@ -230,8 +230,9 @@ describe('.listTokens() top-level convenience — SDK-F09', () => {
   it('proxies to .tokens.listTokens()', async () => {
     restoreFn = installFetchMock(async () => {
       return makeResponse({
-        tokens: [{ id: 1, name: 'T', symbol: 'T', address: '0x123', price: '0.01' }],
-        total: 1,
+        success: true,
+        data: [{ id: 1, name: 'T', symbol: 'T', address: '0x123', price: '0.01' }],
+        meta: { page: 1, limit: 10, total: 1, totalPages: 1 },
       });
     });
 
@@ -381,7 +382,7 @@ describe('.payments.getToken() — SDK-F05', () => {
     assert.equal(token, undefined);
   });
 
-  it('defaults to chainId 97 when not specified', () => {
+  it('defaults to chainId 56 when not specified', () => {
     const al = new AgentLaunch({
       baseUrl: 'https://test.local',
     });
@@ -389,7 +390,7 @@ describe('.payments.getToken() — SDK-F05', () => {
     const token = al.payments.getToken('FET');
 
     assert.ok(token, 'should return a token without explicit chainId');
-    assert.equal(token!.chainId, 97);
+    assert.equal(token!.chainId, 56);
   });
 });
 

--- a/packages/sdk/src/__tests__/onchain-config.test.ts
+++ b/packages/sdk/src/__tests__/onchain-config.test.ts
@@ -39,7 +39,7 @@ describe('CHAIN_CONFIGS — SDK-ON07', () => {
     assert.ok(config, 'chain 56 should exist');
     assert.equal(config.chainId, 56);
     assert.equal(config.name, 'BSC Mainnet');
-    assert.equal(config.fetAddress, '0xBd5df99ABe0E2b1e86BE5eC0039d1e24de28Fe87');
+    assert.equal(config.fetAddress, '0x031b41e504677879370e9DBcF937283A8691Fa7f');
     assert.ok(config.rpcUrl.length > 0, 'should have an RPC URL');
   });
 

--- a/packages/sdk/src/__tests__/tokens.test.ts
+++ b/packages/sdk/src/__tests__/tokens.test.ts
@@ -256,7 +256,7 @@ describe('listTokens()', () => {
 
     const restore = installFetchMock((url) => {
       capturedUrl = url;
-      return Promise.resolve(makeResponse({ tokens: [mockToken], total: 1 }));
+      return Promise.resolve(makeResponse({ success: true, data: [mockToken], meta: { page: 1, limit: 10, total: 1, totalPages: 1 } }));
     });
 
     const client = makeClient();
@@ -271,7 +271,7 @@ describe('listTokens()', () => {
 
     const restore = installFetchMock((url) => {
       capturedUrl = url;
-      return Promise.resolve(makeResponse({ tokens: [], total: 0 }));
+      return Promise.resolve(makeResponse({ success: true, data: [], meta: { page: 2, limit: 20, total: 0, totalPages: 0 } }));
     });
 
     const client = makeClient();
@@ -287,7 +287,7 @@ describe('listTokens()', () => {
 
     const restore = installFetchMock((url) => {
       capturedUrl = url;
-      return Promise.resolve(makeResponse({ tokens: [], total: 0 }));
+      return Promise.resolve(makeResponse({ success: true, data: [], meta: { page: 1, limit: 10, total: 0, totalPages: 0 } }));
     });
 
     const client = makeClient();
@@ -300,7 +300,7 @@ describe('listTokens()', () => {
 
   it('returns token list and total from the API response', async () => {
     const restore = installFetchMock(() =>
-      Promise.resolve(makeResponse({ tokens: [mockToken], total: 1 })),
+      Promise.resolve(makeResponse({ success: true, data: [mockToken], meta: { page: 1, limit: 10, total: 1, totalPages: 1 } })),
     );
 
     const client = makeClient();
@@ -317,7 +317,7 @@ describe('listTokens()', () => {
 
     const restore = installFetchMock(() => {
       callCount++;
-      return Promise.resolve(makeResponse({ tokens: [mockToken], total: 1 }));
+      return Promise.resolve(makeResponse({ success: true, data: [mockToken], meta: { page: 1, limit: 10, total: 1, totalPages: 1 } }));
     });
 
     const client = makeClient();
@@ -330,7 +330,7 @@ describe('listTokens()', () => {
 
   it('returns empty tokens array when no tokens exist', async () => {
     const restore = installFetchMock(() =>
-      Promise.resolve(makeResponse({ tokens: [], total: 0 })),
+      Promise.resolve(makeResponse({ success: true, data: [], meta: { page: 1, limit: 10, total: 0, totalPages: 0 } })),
     );
 
     const client = makeClient();
@@ -346,7 +346,7 @@ describe('listTokens()', () => {
 
     const restore = installFetchMock((url) => {
       capturedUrl = url;
-      return Promise.resolve(makeResponse({ tokens: [], total: 0 }));
+      return Promise.resolve(makeResponse({ success: true, data: [], meta: { page: 1, limit: 10, total: 0, totalPages: 0 } }));
     });
 
     const client = makeClient();

--- a/packages/sdk/src/__tests__/wallet-auth.test.ts
+++ b/packages/sdk/src/__tests__/wallet-auth.test.ts
@@ -113,16 +113,16 @@ describe('authenticateWithWallet — input validation', () => {
     const { authenticateWithWallet } = await import('../wallet-auth.js');
 
     // This test will fail at the dependency check if not installed,
-    // or at the API call step if installed
+    // or at the key derivation step (all-zero key is invalid for secp256k1),
+    // or at the API call step if everything else succeeds.
     await assert.rejects(
       () => authenticateWithWallet('0x' + '0'.repeat(64)),
       (err: Error) => {
-        // Should get past the format validation
+        // Should get past the format validation — any error that is NOT
+        // "Invalid private key format" proves the 0x prefix was accepted.
         assert.ok(
-          err.message.includes('cosmjs/crypto') ||
-          err.message.includes('bech32') ||
-          err.message.includes('challenge') ||
-          err.message.includes('ENOTFOUND'),
+          !err.message.includes('Invalid private key format'),
+          `Should accept 0x prefix and pass format validation. Got: ${err.message}`,
         );
         return true;
       },

--- a/packages/sdk/src/agentlaunch.ts
+++ b/packages/sdk/src/agentlaunch.ts
@@ -11,7 +11,7 @@
  *
  * const { data } = await al.tokens.tokenize({
  *   agentAddress: 'agent1qf8xfhsc8hg4g5l0nhtj...',
- *   chainId: 97,
+ *   chainId: 56,
  * });
  *
  * const link = al.handoff.generateDeployLink(data.token_id);
@@ -429,7 +429,7 @@ export interface TradingNamespace {
    * Get a custodial wallet address and balances.
    * Omit agentAddress to get the user's own wallet.
    * Pass an agentAddress to get that agent's autonomous trading wallet.
-   * @param chainId       Chain to query (default: 97 = BSC Testnet).
+   * @param chainId       Chain to query (default: 56 = BSC Mainnet).
    * @param agentAddress  Agent address (agent1q...). Omit for user wallet.
    * @see getWallet
    */

--- a/packages/sdk/src/delegation.ts
+++ b/packages/sdk/src/delegation.ts
@@ -27,14 +27,14 @@ import { getStorage, putStorage } from './storage.js';
  * @param tokenAddress - ERC-20 contract address
  * @param owner - Address that granted the allowance
  * @param spender - Address allowed to spend
- * @param chainId - Chain ID (default: 97)
+ * @param chainId - Chain ID (default: 56)
  * @returns SpendingLimit with on-chain data
  */
 export async function checkAllowance(
   tokenAddress: string,
   owner: string,
   spender: string,
-  chainId = 97,
+  chainId = 56,
 ): Promise<SpendingLimit> {
   validateEthAddress(tokenAddress);
   validateEthAddress(owner);
@@ -100,7 +100,7 @@ export function createSpendingLimitHandoff(
   params: { tokenSymbol: string; amount: string; chainId?: number },
   agentAddress: string,
 ): string {
-  const chainId = params.chainId ?? 97;
+  const chainId = params.chainId ?? 56;
   const token = getToken(params.tokenSymbol, chainId);
   if (!token) {
     throw new Error(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -17,7 +17,7 @@
  * const { data } = await tokenize({
  *   agentAddress: 'agent1qf8xfhsc8hg4g5l0nhtj...',
  *   name: 'My Agent Token',
- *   chainId: 97,
+ *   chainId: 56,
  * });
  *
  * const link = generateDeployLink(data.token_id);

--- a/packages/sdk/src/onchain.ts
+++ b/packages/sdk/src/onchain.ts
@@ -24,7 +24,7 @@ import type { AgentLaunchClient } from './client.js';
 export interface OnchainConfig {
   /** Wallet private key. Falls back to WALLET_PRIVATE_KEY env var. */
   privateKey?: string;
-  /** Chain ID (97 = BSC Testnet, 56 = BSC Mainnet). Default: 97. */
+  /** Chain ID (56 = BSC Mainnet, 97 = BSC Testnet). Default: 56. */
   chainId?: number;
   /** Slippage tolerance as a percentage (0-100). Default: 5. */
   slippagePercent?: number;
@@ -94,6 +94,8 @@ export interface ChainConfig {
   rpcUrl: string;
   /** FET token contract address on this chain. */
   fetAddress: string;
+  /** FETAgentVerseDeployer contract address on this chain (if deployed). */
+  deployerAddress?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -130,17 +132,18 @@ export const ERC20_ABI = [
 
 /** Supported chain configurations. */
 export const CHAIN_CONFIGS: Record<number, ChainConfig> = {
+  56: {
+    chainId: 56,
+    name: 'BSC Mainnet',
+    rpcUrl: 'https://bsc-dataseed1.binance.org',
+    fetAddress: '0x031b41e504677879370e9DBcF937283A8691Fa7f',
+    deployerAddress: '0xeDecbC8E118288e1365Db14c9c2f3d51E91Cc247',
+  },
   97: {
     chainId: 97,
     name: 'BSC Testnet',
     rpcUrl: 'https://data-seed-prebsc-1-s1.binance.org:8545',
     fetAddress: '0x304ddf3eE068c53514f782e2341B71A80c8aE3C7',
-  },
-  56: {
-    chainId: 56,
-    name: 'BSC Mainnet',
-    rpcUrl: 'https://bsc-dataseed1.binance.org',
-    fetAddress: '0xBd5df99ABe0E2b1e86BE5eC0039d1e24de28Fe87',
   },
 };
 
@@ -175,7 +178,7 @@ function resolvePrivateKey(config?: OnchainConfig): string {
 
 /** Resolve chain configuration from chain ID. */
 function resolveChain(config?: OnchainConfig): ChainConfig {
-  const chainId = config?.chainId ?? Number(process.env['CHAIN_ID'] ?? 97);
+  const chainId = config?.chainId ?? Number(process.env['CHAIN_ID'] ?? 56);
   const chain = CHAIN_CONFIGS[chainId];
   if (!chain) {
     throw new Error(

--- a/packages/sdk/src/payments.ts
+++ b/packages/sdk/src/payments.ts
@@ -24,6 +24,21 @@ import { validateEthAddress } from './handoff.js';
 
 /** Well-known token addresses per chain. */
 export const KNOWN_TOKENS: PaymentToken[] = [
+  // BSC Mainnet (56)
+  {
+    symbol: 'FET',
+    contractAddress: '0x031b41e504677879370e9DBcF937283A8691Fa7f',
+    decimals: 18,
+    chainId: 56,
+    isStablecoin: false,
+  },
+  {
+    symbol: 'USDC',
+    contractAddress: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+    decimals: 18,
+    chainId: 56,
+    isStablecoin: true,
+  },
   // BSC Testnet (97)
   {
     symbol: 'FET',
@@ -39,31 +54,16 @@ export const KNOWN_TOKENS: PaymentToken[] = [
     chainId: 97,
     isStablecoin: true,
   },
-  // BSC Mainnet (56)
-  {
-    symbol: 'FET',
-    contractAddress: '0xBd5df99ABe0E2b1e86BE5eC0039d1e24de28Fe87',
-    decimals: 18,
-    chainId: 56,
-    isStablecoin: false,
-  },
-  {
-    symbol: 'USDC',
-    contractAddress: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-    decimals: 18,
-    chainId: 56,
-    isStablecoin: true,
-  },
 ];
 
 /**
  * Look up a known token by symbol and chain.
  *
  * @param symbol - Token symbol (e.g. "FET", "USDC")
- * @param chainId - Chain ID (default: 97)
+ * @param chainId - Chain ID (default: 56)
  * @returns PaymentToken or undefined if not found
  */
-export function getToken(symbol: string, chainId = 97): PaymentToken | undefined {
+export function getToken(symbol: string, chainId = 56): PaymentToken | undefined {
   return KNOWN_TOKENS.find(
     (t) => t.symbol.toUpperCase() === symbol.toUpperCase() && t.chainId === chainId,
   );
@@ -72,7 +72,7 @@ export function getToken(symbol: string, chainId = 97): PaymentToken | undefined
 /**
  * List all known tokens for a chain.
  */
-export function getTokensForChain(chainId = 97): PaymentToken[] {
+export function getTokensForChain(chainId = 56): PaymentToken[] {
   return KNOWN_TOKENS.filter((t) => t.chainId === chainId);
 }
 
@@ -98,13 +98,13 @@ async function loadEthers(): Promise<any> {
  *
  * @param tokenAddress - ERC-20 contract address
  * @param walletAddress - Wallet to check
- * @param chainId - Chain ID (default: 97)
+ * @param chainId - Chain ID (default: 56)
  * @returns Balance as a decimal string
  */
 export async function getTokenBalance(
   tokenAddress: string,
   walletAddress: string,
-  chainId = 97,
+  chainId = 56,
 ): Promise<string> {
   validateEthAddress(tokenAddress);
   validateEthAddress(walletAddress);
@@ -129,13 +129,13 @@ export async function getTokenBalance(
  *
  * @param walletAddress - Wallet to check
  * @param tokenSymbols - Array of token symbols (default: all known tokens for chain)
- * @param chainId - Chain ID (default: 97)
+ * @param chainId - Chain ID (default: 56)
  * @returns Record of symbol -> balance string
  */
 export async function getMultiTokenBalances(
   walletAddress: string,
   tokenSymbols?: string[],
-  chainId = 97,
+  chainId = 56,
 ): Promise<Record<string, string>> {
   validateEthAddress(walletAddress);
   const ethers = await loadEthers();
@@ -176,7 +176,7 @@ export async function getMultiTokenBalances(
  * @param to - Recipient address
  * @param amount - Amount as decimal string
  * @param privateKey - Sender's private key
- * @param chainId - Chain ID (default: 97)
+ * @param chainId - Chain ID (default: 56)
  * @returns Transaction hash
  */
 export async function transferToken(
@@ -184,7 +184,7 @@ export async function transferToken(
   to: string,
   amount: string,
   privateKey: string,
-  chainId = 97,
+  chainId = 56,
 ): Promise<{ txHash: string; blockNumber: number }> {
   validateEthAddress(tokenAddress);
   validateEthAddress(to);

--- a/packages/sdk/src/tokens.ts
+++ b/packages/sdk/src/tokens.ts
@@ -57,7 +57,7 @@ function defaultClient(): AgentLaunchClient {
  * const { data } = await tokenize({
  *   agentAddress: 'agent1qf8xfhsc8hg4g5l0nhtj5hxxkyd46c64qx...',
  *   name: 'My Agent',
- *   chainId: 97,
+ *   chainId: 56,
  * });
  * console.log(data.handoff_link); // https://agent-launch.ai/deploy/42
  * ```

--- a/packages/sdk/src/trading.ts
+++ b/packages/sdk/src/trading.ts
@@ -70,7 +70,7 @@ interface ApiSuccess<T> {
  * Derivation uses BIP-44: `m/44'/60'/0'/0/{hash(identity) % MAX_HD_INDEX}`.
  * Private keys are never returned.
  *
- * @param chainId       Chain to query balances on (default: 97 = BSC Testnet).
+ * @param chainId       Chain to query balances on (default: 56 = BSC Mainnet).
  * @param agentAddress  Agent address (agent1q...) to query. Omit for user wallet.
  * @param client        Optional pre-configured AgentLaunchClient.
  */

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -551,7 +551,7 @@ export interface PaymentToken {
   contractAddress: string;
   /** Token decimals (usually 18 for FET, 18 for USDC on BSC). */
   decimals: number;
-  /** Chain ID (97 = BSC Testnet, 56 = BSC Mainnet). */
+  /** Chain ID (56 = BSC Mainnet, 97 = BSC Testnet). */
   chainId: number;
   /** Whether this is a stablecoin (e.g. USDC, USDT). */
   isStablecoin: boolean;

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentlaunch-templates",
-  "version": "0.4.11",
+  "version": "1.0.0",
   "description": "Agent code templates for the AgentLaunch platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/templates/src/claude-context.ts
+++ b/packages/templates/src/claude-context.ts
@@ -22,7 +22,7 @@ When working with AgentLaunch tokens and the platform API:
 - NO creator fee. The 2% fee has NO split. All to protocol.
 - Total buy supply: 800,000,000 tokens per token
 - Buy price difference: 1000 (10x)
-- Default chain: BSC (testnet=97, mainnet=56)
+- Default chain: BSC Mainnet (56). Also supported: BSC Testnet (97)
 
 ## API Authentication
 
@@ -292,16 +292,16 @@ When reviewing or writing code that makes API calls:
 
 ## Multi-Token Support
 
-The toolkit supports FET and USDC on BSC (Testnet chain 97, Mainnet chain 56).
+The toolkit supports FET and USDC on BSC (Mainnet chain 56, Testnet chain 97).
 
 ### Known Token Addresses
 
 | Token | Chain | Address |
 |-------|-------|---------|
+| FET | BSC Mainnet (56) | \`0x031b41e504677879370e9DBcF937283A8691Fa7f\` |
 | FET | BSC Testnet (97) | \`0x304ddf3eE068c53514f782e2341B71A80c8aE3C7\` |
-| FET | BSC Mainnet (56) | \`0xBd5df99ABe0E2b1e86BE5eC0039d1e24de28Fe87\` |
-| USDC | BSC Testnet (97) | \`0x64544969ed7EBf5f083679233325356EbE738930\` |
 | USDC | BSC Mainnet (56) | \`0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d\` |
+| USDC | BSC Testnet (97) | \`0x64544969ed7EBf5f083679233325356EbE738930\` |
 
 ### Token Registry
 
@@ -309,8 +309,8 @@ Use \`getToken(symbol, chainId)\` to look up tokens. Never hardcode addresses.
 
 \`\`\`typescript
 import { getToken, KNOWN_TOKENS } from 'agentlaunch-sdk';
-const fet = getToken('FET', 97);   // PaymentToken object
-const usdc = getToken('USDC', 97); // PaymentToken object
+const fet = getToken('FET', 56);   // PaymentToken object
+const usdc = getToken('USDC', 56); // PaymentToken object
 \`\`\`
 
 ## Spending Delegation
@@ -333,7 +333,7 @@ import { checkAllowance, spendFromDelegation, createSpendingLimitHandoff } from 
 const link = createSpendingLimitHandoff({ tokenSymbol: 'FET', amount: '100' }, agentWallet);
 
 // Check on-chain allowance
-const limit = await checkAllowance(tokenAddress, ownerAddress, spenderAddress, 97);
+const limit = await checkAllowance(tokenAddress, ownerAddress, spenderAddress, 56);
 
 // Spend from delegation
 const result = await spendFromDelegation(tokenAddress, owner, recipient, '10');
@@ -1243,7 +1243,7 @@ Build, deploy, and tokenize an agent in one guided flow.
 7. **Tokenize on AgentLaunch**:
    - Use the \`create_token_record\` MCP tool
    - POST /agents/tokenize with name, symbol, description, chainId
-   - Default chain: BSC Testnet (97)
+   - Default chain: BSC Mainnet (56)
 
 8. **Return results to user**:
    - Agent address (agent1q...)
@@ -1974,7 +1974,7 @@ Create a tradeable token for an existing Agentverse agent.
 3. **Create token record**: Use the \`create_token_record\` MCP tool or
    POST /agents/tokenize with:
    - agentAddress, name, symbol, description
-   - chainId (default: 97 for BSC Testnet)
+   - chainId (default: 56 for BSC Mainnet)
 4. **Return handoff link**: Show the deploy link and instructions.
 5. **Explain next steps**:
    - Human clicks the link
@@ -2223,7 +2223,7 @@ const { data } = await tokenize({
   agentAddress: 'agent1q...',
   name: 'My Agent',
   symbol: 'MYAG',
-  chainId: 97,
+  chainId: 56,
 });
 
 console.log(data.handoff_link); // Share with human
@@ -2539,7 +2539,7 @@ async function main() {
     name: 'My Agent',
     symbol: 'MYAG',
     description: 'AI research assistant for on-chain analysis',
-    chainId: 97, // BSC Testnet
+    chainId: 56, // BSC Mainnet
   });
 
   console.log('Token ID:', data.token_id);
@@ -3038,7 +3038,7 @@ export function buildSwarmConfig(ctx: SwarmContext): string {
     {
       name: ctx.swarmName,
       type: "swarm",
-      chain: 97,
+      chain: 56,
       deployedAt: ctx.deployedAt,
       agents,
       peerAddresses: ctx.peerAddresses,

--- a/packages/templates/src/generator.ts
+++ b/packages/templates/src/generator.ts
@@ -530,7 +530,7 @@ function buildAgentlaunchConfig(
     {
       name,
       template: template.name,
-      chain: 97,
+      chain: 56,
       agentAddress: null,
       tokenAddress: null,
     },

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -440,9 +440,11 @@ When tokenizing, pick the right category:
 
 ---
 
-## Testnet First
+## Testing on Testnet
 
-Test everything on BSC Testnet (chainId: 97) before mainnet.
+> **BSC Mainnet (chainId: 56) is the default.** Use BSC Testnet (chainId: 97) for development and testing only.
+
+To test on testnet, pass `chainId: 97` to the tokenize API or use `--chain 97` in the CLI.
 
 **Get testnet tokens:**
 ```


### PR DESCRIPTION
## Summary

Switch all toolkit defaults from BSC Testnet (chainId 97) to BSC Mainnet (chainId 56). This is a **breaking change** for users relying on testnet being default — they now need to explicitly pass `chainId: 97`.

## Versions

| Package | Old | New | Bump |
|---------|-----|-----|------|
| agentlaunch-sdk | 0.2.15 | 0.3.0 | minor (breaking default) |
| agentlaunch (CLI) | 1.2.11 | 2.0.0 | major |
| agent-launch-mcp | 2.3.8 | 3.0.0 | major |
| agentlaunch-templates | 0.4.11 | 1.0.0 | major (mainnet ready) |

## Changes

### Source (26 files)
- All default chainId values: 97 → 56
- Mainnet contract `0xeDecbC8E118288e1365Db14c9c2f3d51E91Cc247` added to on-chain config
- Mainnet FET address `0x031b41e504677879370e9DBcF937283A8691Fa7f` configured
- Cross-package dependencies updated

### Documentation (8 files)
- CLAUDE.md, README.md, TUTORIAL.md, getting-started.md, SKILL.md
- Package READMEs (SDK, CLI, MCP)

### Tests (7 files)
- Fixed 4 pre-existing test failures (listTokens response shape, wallet-auth 0x prefix)
- Updated default-chain assertions (97 → 56)
- Added `generate_wallet` to expected tools list

### Test Results
- SDK: 320/320 ✅
- CLI: 89/89 ✅
- MCP: 124/124 ✅
- Templates: 234/234 ✅
- **Total: 767/767 pass**

## Key: Testnet Still Supported
BSC Testnet (97) is still fully functional — just not the default anymore. Pass `chainId: 97` explicitly to use it.