### PR TITLE
chore: rename packages to @fetchai/ scope for npm publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -556,6 +556,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fetchai/agent-launch-cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
+    "node_modules/@fetchai/agent-launch-mcp": {
+      "resolved": "packages/mcp",
+      "link": true
+    },
+    "node_modules/@fetchai/agent-launch-sdk": {
+      "resolved": "packages/sdk",
+      "link": true
+    },
+    "node_modules/@fetchai/agent-launch-templates": {
+      "resolved": "packages/templates",
+      "link": true
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
@@ -720,22 +736,6 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "license": "MIT"
-    },
-    "node_modules/agent-launch-mcp": {
-      "resolved": "packages/mcp",
-      "link": true
-    },
-    "node_modules/agentlaunch": {
-      "resolved": "packages/cli",
-      "link": true
-    },
-    "node_modules/agentlaunch-sdk": {
-      "resolved": "packages/sdk",
-      "link": true
-    },
-    "node_modules/agentlaunch-templates": {
-      "resolved": "packages/templates",
-      "link": true
     },
     "node_modules/ajv": {
       "version": "8.18.0",
@@ -2150,13 +2150,13 @@
       }
     },
     "packages/cli": {
-      "name": "agentlaunch",
-      "version": "1.2.11",
+      "name": "@fetchai/agent-launch-cli",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.0",
-        "agentlaunch-sdk": "^0.2.14",
-        "agentlaunch-templates": "0.4.11",
+        "@fetchai/agent-launch-sdk": "^0.3.0",
+        "@fetchai/agent-launch-templates": "^1.0.0",
         "bech32": "^2.0.0",
         "commander": "^12.0.0",
         "ethers": "^6.0.0",
@@ -2223,13 +2223,13 @@
       "license": "Apache-2.0"
     },
     "packages/mcp": {
-      "name": "agent-launch-mcp",
-      "version": "2.3.8",
+      "name": "@fetchai/agent-launch-mcp",
+      "version": "3.0.0",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.0",
+        "@fetchai/agent-launch-sdk": "^0.3.0",
+        "@fetchai/agent-launch-templates": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.28.0",
-        "agentlaunch-sdk": "^0.2.11",
-        "agentlaunch-templates": "0.4.11",
         "bech32": "^2.0.0",
         "dotenv": "^17.3.1",
         "ethers": "^6.0.0"
@@ -2295,8 +2295,8 @@
       "license": "Apache-2.0"
     },
     "packages/sdk": {
-      "name": "agentlaunch-sdk",
-      "version": "0.2.15",
+      "name": "@fetchai/agent-launch-sdk",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@cosmjs/crypto": "^0.38.1",
@@ -2325,8 +2325,8 @@
       }
     },
     "packages/templates": {
-      "name": "agentlaunch-templates",
-      "version": "0.4.11",
+      "name": "@fetchai/agent-launch-templates",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.3.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/fetchai/agent-launch-toolkit"
+    "url": "git+https://github.com/fetchai/agent-launch-toolkit.git"
   },
   "homepage": "https://agent-launch.ai",
   "bugs": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentlaunch",
+  "name": "@fetchai/agent-launch-cli",
   "version": "2.0.0",
   "description": "CLI for AgentLaunch — scaffold, deploy, and tokenize AI agents from the command line",
   "type": "module",
@@ -24,8 +24,8 @@
   "license": "MIT",
   "dependencies": {
     "@cosmjs/crypto": "^0.32.0",
-    "agentlaunch-sdk": "^0.3.0",
-    "agentlaunch-templates": "^1.0.0",
+    "@fetchai/agent-launch-sdk": "^0.3.0",
+    "@fetchai/agent-launch-templates": "^1.0.0",
     "bech32": "^2.0.0",
     "commander": "^12.0.0",
     "ethers": "^6.0.0",

--- a/packages/cli/src/commands/alliance.ts
+++ b/packages/cli/src/commands/alliance.ts
@@ -14,7 +14,7 @@ import {
   generateSwarmFromOrg,
   summarizeSwarm,
   type OrgChart,
-} from "agentlaunch-templates";
+} from '@fetchai/agent-launch-templates';
 import { scaffoldSwarm, deploySwarmAgents } from "../lib/deploy-swarm.js";
 
 // The full 27-agent ASI Alliance org chart

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -20,7 +20,7 @@ import {
   authenticateWithWallet,
   deriveCosmosAddress,
   type WalletAuthResult,
-} from "agentlaunch-sdk";
+} from '@fetchai/agent-launch-sdk';
 import { writeConfig, maskKey, tryGetApiKey } from "../config.js";
 
 /**

--- a/packages/cli/src/commands/buy.ts
+++ b/packages/cli/src/commands/buy.ts
@@ -7,7 +7,7 @@
  */
 
 import { Command } from "commander";
-import { calculateBuy, buyTokens, executeBuy, DEFAULT_SLIPPAGE_PERCENT } from "agentlaunch-sdk";
+import { calculateBuy, buyTokens, executeBuy, DEFAULT_SLIPPAGE_PERCENT } from '@fetchai/agent-launch-sdk';
 import { getPublicClient } from "../http.js";
 
 export function registerBuyCommand(program: Command): void {

--- a/packages/cli/src/commands/connect-logs.ts
+++ b/packages/cli/src/commands/connect-logs.ts
@@ -10,7 +10,7 @@
  */
 
 import { Command } from "commander";
-import { connectionLogs } from "agentlaunch-sdk";
+import { connectionLogs } from '@fetchai/agent-launch-sdk';
 import { requireApiKey } from "../config.js";
 
 const DEFAULT_LIMIT = 50;

--- a/packages/cli/src/commands/connect-status.ts
+++ b/packages/cli/src/commands/connect-status.ts
@@ -8,8 +8,8 @@
  */
 
 import { Command } from "commander";
-import { connectionStatus } from "agentlaunch-sdk";
-import type { ConnectionStatus } from "agentlaunch-sdk";
+import { connectionStatus } from '@fetchai/agent-launch-sdk';
+import type { ConnectionStatus } from '@fetchai/agent-launch-sdk';
 import { requireApiKey } from "../config.js";
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/connect-update.ts
+++ b/packages/cli/src/commands/connect-update.ts
@@ -24,7 +24,7 @@
  */
 
 import { Command } from "commander";
-import { updateConnection, type ConnectConfig } from "agentlaunch-sdk";
+import { updateConnection, type ConnectConfig } from '@fetchai/agent-launch-sdk';
 import { requireApiKey } from "../config.js";
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -20,7 +20,7 @@
  */
 
 import { Command } from "commander";
-import { connectAgent, type ConnectResult } from "agentlaunch-sdk";
+import { connectAgent, type ConnectResult } from '@fetchai/agent-launch-sdk';
 import { requireApiKey } from "../config.js";
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -23,9 +23,9 @@ import path from "node:path";
 import readline from "node:readline";
 import { spawn } from "node:child_process";
 import { Command } from "commander";
-import { deployAgent, getFrontendUrl } from "agentlaunch-sdk";
+import { deployAgent, getFrontendUrl } from '@fetchai/agent-launch-sdk';
 import { execSync } from "node:child_process";
-import { generateFromTemplate, generateSystemPrompt, generateWelcomeMessage, listTemplates, RULES, SKILLS, DOCS, EXAMPLES, buildPackageJson, CURSOR_MCP_CONFIG, CURSOR_RULES, buildSwarmClaudeMd, buildSwarmConfig, buildSwarmPackageJson, buildProjectSkills, type SwarmContext } from "agentlaunch-templates";
+import { generateFromTemplate, generateSystemPrompt, generateWelcomeMessage, listTemplates, RULES, SKILLS, DOCS, EXAMPLES, buildPackageJson, CURSOR_MCP_CONFIG, CURSOR_RULES, buildSwarmClaudeMd, buildSwarmConfig, buildSwarmPackageJson, buildProjectSkills, type SwarmContext } from '@fetchai/agent-launch-templates';
 import { getClient, agentverseRequest } from "../http.js";
 import { requireApiKey, buildMcpConfig } from "../config.js";
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -17,7 +17,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Command } from "commander";
-import { deployAgent, type OptimizationCheckItem } from "agentlaunch-sdk";
+import { deployAgent, type OptimizationCheckItem } from '@fetchai/agent-launch-sdk';
 import { requireApiKey } from "../config.js";
 
 function printOptimizationChecklist(items: OptimizationCheckItem[]): void {

--- a/packages/cli/src/commands/holders.ts
+++ b/packages/cli/src/commands/holders.ts
@@ -10,7 +10,7 @@
  */
 
 import { Command } from "commander";
-import { getFrontendUrl } from "agentlaunch-sdk";
+import { getFrontendUrl } from '@fetchai/agent-launch-sdk';
 import { getPublicClient } from "../http.js";
 
 interface Holder {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -703,7 +703,7 @@ npx agentlaunch status <address> --json
 
 ### 3. SDK (TypeScript agents)
 \`\`\`ts
-import { tokenize, listTokens, getToken } from 'agentlaunch-sdk';
+import { tokenize, listTokens, getToken } from '@fetchai/agent-launch-sdk';
 const result = await tokenize({ agentAddress, name, symbol });
 \`\`\`
 
@@ -791,7 +791,7 @@ agentlaunch tokenize \\
 
 ### Path B — SDK
 \`\`\`ts
-import { tokenize } from 'agentlaunch-sdk';
+import { tokenize } from '@fetchai/agent-launch-sdk';
 const result = await tokenize({
   agentAddress: 'agent1q...',
   name: 'My Agent',
@@ -842,10 +842,10 @@ Token is live on BSC Testnet
 }
 
 function getSdkReferenceDoc(): string {
-  return `# SDK Reference — agentlaunch-sdk
+  return `# SDK Reference — @fetchai/agent-launch-sdk
 
 \`\`\`bash
-npm install agentlaunch-sdk
+npm install @fetchai/agent-launch-sdk
 # For on-chain trading (buy/sell):
 npm install ethers@^6
 \`\`\`
@@ -855,7 +855,7 @@ Node.js 18+ required.
 ## Configuration
 
 \`\`\`ts
-import { AgentLaunchClient } from 'agentlaunch-sdk';
+import { AgentLaunchClient } from '@fetchai/agent-launch-sdk';
 
 // Option 1: Environment variable (auto-read)
 // Set AGENTVERSE_API_KEY or AGENT_LAUNCH_API_KEY
@@ -871,7 +871,7 @@ const client = new AgentLaunchClient({
 
 ### tokenize(params) — Create token record
 \`\`\`ts
-import { tokenize } from 'agentlaunch-sdk';
+import { tokenize } from '@fetchai/agent-launch-sdk';
 const result = await tokenize({
   agentAddress: 'agent1q...',
   name: 'My Agent',    // max 32 chars
@@ -885,34 +885,34 @@ const result = await tokenize({
 
 ### listTokens(params?) — List tokens
 \`\`\`ts
-import { listTokens } from 'agentlaunch-sdk';
+import { listTokens } from '@fetchai/agent-launch-sdk';
 const tokens = await listTokens({ page: 1, limit: 20 });
 \`\`\`
 
 ### getToken(address) — Get token by address
 \`\`\`ts
-import { getToken } from 'agentlaunch-sdk';
+import { getToken } from '@fetchai/agent-launch-sdk';
 const token = await getToken('0x...');
 // token.price, token.marketCap, token.holders, token.progress
 \`\`\`
 
 ### calculateBuy(address, fetAmount, client?) — Preview buy
 \`\`\`ts
-import { calculateBuy } from 'agentlaunch-sdk';
+import { calculateBuy } from '@fetchai/agent-launch-sdk';
 const preview = await calculateBuy('0x...', '10');
 // preview.tokensReceived, preview.pricePerToken, preview.fee, preview.priceImpact
 \`\`\`
 
 ### calculateSell(address, tokenAmount, client?) — Preview sell
 \`\`\`ts
-import { calculateSell } from 'agentlaunch-sdk';
+import { calculateSell } from '@fetchai/agent-launch-sdk';
 const preview = await calculateSell('0x...', '1000000');
 // preview.fetReceived, preview.pricePerToken, preview.fee, preview.netFetReceived
 \`\`\`
 
 ### buyTokens(address, fetAmount, options) — Buy on-chain
 \`\`\`ts
-import { buyTokens } from 'agentlaunch-sdk';
+import { buyTokens } from '@fetchai/agent-launch-sdk';
 // Requires WALLET_PRIVATE_KEY env var
 const result = await buyTokens('0x...', '10', { chainId: 56, slippagePercent: 5 });
 // result.txHash, result.tokensReceived, result.fetSpent, result.fee
@@ -920,7 +920,7 @@ const result = await buyTokens('0x...', '10', { chainId: 56, slippagePercent: 5 
 
 ### sellTokens(address, tokenAmount, options) — Sell on-chain
 \`\`\`ts
-import { sellTokens } from 'agentlaunch-sdk';
+import { sellTokens } from '@fetchai/agent-launch-sdk';
 // Requires WALLET_PRIVATE_KEY env var
 const result = await sellTokens('0x...', '1000000', { chainId: 56 });
 // result.txHash, result.fetReceived, result.tokensSold, result.fee
@@ -928,7 +928,7 @@ const result = await sellTokens('0x...', '1000000', { chainId: 56 });
 
 ### deployAgent(params) — Deploy to Agentverse
 \`\`\`ts
-import { deployAgent } from 'agentlaunch-sdk';
+import { deployAgent } from '@fetchai/agent-launch-sdk';
 const deployed = await deployAgent({
   apiKey: 'av-...',
   agentName: 'My Agent',
@@ -939,7 +939,7 @@ const deployed = await deployAgent({
 
 ### getMultiTokenBalances(address, symbols?, chainId?) — Wallet balances
 \`\`\`ts
-import { getMultiTokenBalances } from 'agentlaunch-sdk';
+import { getMultiTokenBalances } from '@fetchai/agent-launch-sdk';
 // Requires WALLET_PRIVATE_KEY or pass address directly
 const balances = await getMultiTokenBalances('0x...', ['FET', 'BNB'], 56);
 // { FET: '150.0000', BNB: '0.0012' }
@@ -1193,7 +1193,7 @@ Humans can sign transactions. The Handoff Protocol bridges this gap.
 ## Code Example
 
 \`\`\`ts
-import { tokenize } from 'agentlaunch-sdk';
+import { tokenize } from '@fetchai/agent-launch-sdk';
 
 const result = await tokenize({
   agentAddress: 'agent1q...',
@@ -1289,7 +1289,7 @@ agentlaunch sell 0x<address> --amount 1000000 --dry-run
 
 \`\`\`ts
 // SDK preview
-import { calculateBuy, calculateSell } from 'agentlaunch-sdk';
+import { calculateBuy, calculateSell } from '@fetchai/agent-launch-sdk';
 const buy = await calculateBuy('0x...', '10');
 const sell = await calculateSell('0x...', '1000000');
 \`\`\`

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -7,7 +7,7 @@
  */
 
 import { Command } from "commander";
-import { getFrontendUrl } from "agentlaunch-sdk";
+import { getFrontendUrl } from '@fetchai/agent-launch-sdk';
 import { getPublicClient } from "../http.js";
 
 interface TokenItem {

--- a/packages/cli/src/commands/marketing.ts
+++ b/packages/cli/src/commands/marketing.ts
@@ -14,7 +14,7 @@ import {
   generateSwarmFromOrg,
   summarizeSwarm,
   EXAMPLE_ORGS,
-} from "agentlaunch-templates";
+} from '@fetchai/agent-launch-templates';
 import { scaffoldSwarm, deploySwarmAgents } from "../lib/deploy-swarm.js";
 
 interface MarketingOptions {

--- a/packages/cli/src/commands/optimize.ts
+++ b/packages/cli/src/commands/optimize.ts
@@ -11,7 +11,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Command } from "commander";
-import { updateAgent, type OptimizationCheckItem } from "agentlaunch-sdk";
+import { updateAgent, type OptimizationCheckItem } from '@fetchai/agent-launch-sdk';
 import { requireApiKey } from "../config.js";
 
 function printOptimizationChecklist(items: OptimizationCheckItem[]): void {

--- a/packages/cli/src/commands/org-template.ts
+++ b/packages/cli/src/commands/org-template.ts
@@ -6,7 +6,7 @@
  */
 
 import { Command } from "commander";
-import { generateOrgTemplate } from "agentlaunch-templates";
+import { generateOrgTemplate } from '@fetchai/agent-launch-templates';
 
 export function registerOrgTemplateCommand(program: Command): void {
   program

--- a/packages/cli/src/commands/pay.ts
+++ b/packages/cli/src/commands/pay.ts
@@ -12,8 +12,8 @@ import {
   transferToken,
   createInvoice,
   listInvoices,
-} from "agentlaunch-sdk";
-import type { InvoiceStatus, TokenAmount } from "agentlaunch-sdk";
+} from '@fetchai/agent-launch-sdk';
+import type { InvoiceStatus, TokenAmount } from '@fetchai/agent-launch-sdk';
 
 export function registerPayCommand(program: Command): void {
   // --- pay ---

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -24,7 +24,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Command } from "commander";
-import { generateFromTemplate, listTemplates, getTemplate, getCanonicalName, RULES, SKILLS, CURSOR_MCP_CONFIG, CURSOR_RULES } from "agentlaunch-templates";
+import { generateFromTemplate, listTemplates, getTemplate, getCanonicalName, RULES, SKILLS, CURSOR_MCP_CONFIG, CURSOR_RULES } from '@fetchai/agent-launch-templates';
 import { tryGetApiKey, buildMcpConfig } from "../config.js";
 
 /** Map legacy --type values to current template names. */

--- a/packages/cli/src/commands/sell.ts
+++ b/packages/cli/src/commands/sell.ts
@@ -7,7 +7,7 @@
  */
 
 import { Command } from "commander";
-import { calculateSell, sellTokens, executeSell } from "agentlaunch-sdk";
+import { calculateSell, sellTokens, executeSell } from '@fetchai/agent-launch-sdk';
 import { getPublicClient } from "../http.js";
 
 export function registerSellCommand(program: Command): void {

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -91,7 +91,7 @@ Authentication:
   Get key:    https://agentverse.ai/profile/api-keys
 
 Tooling:
-  SDK:        npm install agentlaunch-sdk
+  SDK:        npm install @fetchai/agent-launch-sdk
   CLI:        npx agentlaunch
   MCP:        npx agent-launch-mcp (30+ tools)
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -7,7 +7,7 @@
  */
 
 import { Command } from "commander";
-import { getFrontendUrl } from "agentlaunch-sdk";
+import { getFrontendUrl } from '@fetchai/agent-launch-sdk';
 import { getPublicClient } from "../http.js";
 
 interface TokenDetail {

--- a/packages/cli/src/commands/swarm-from-org.ts
+++ b/packages/cli/src/commands/swarm-from-org.ts
@@ -20,8 +20,8 @@ import {
   getPreset,
   type OrgChart,
   type SwarmConfig,
-} from "agentlaunch-templates";
-import { deployAgent } from "agentlaunch-sdk";
+} from '@fetchai/agent-launch-templates';
+import { deployAgent } from '@fetchai/agent-launch-sdk';
 
 interface SwarmFromOrgOptions {
   dryRun?: boolean;

--- a/packages/cli/src/commands/tokenize.ts
+++ b/packages/cli/src/commands/tokenize.ts
@@ -13,7 +13,7 @@
  */
 
 import { Command } from "commander";
-import { getFrontendUrl } from "agentlaunch-sdk";
+import { getFrontendUrl } from '@fetchai/agent-launch-sdk';
 import { getClient } from "../http.js";
 
 interface TokenizeBody {

--- a/packages/cli/src/commands/wallet.ts
+++ b/packages/cli/src/commands/wallet.ts
@@ -15,7 +15,7 @@ import {
   checkAllowance,
   createSpendingLimitHandoff,
   getWallet,
-} from "agentlaunch-sdk";
+} from '@fetchai/agent-launch-sdk';
 
 async function runBalances(options: { address?: string; token?: string; chain: string; json?: boolean }): Promise<void> {
   const chainId = parseInt(options.chain, 10);

--- a/packages/cli/src/http.ts
+++ b/packages/cli/src/http.ts
@@ -6,7 +6,7 @@
  * bearer-token auth which is a different auth domain.
  */
 
-import { AgentLaunchClient } from "agentlaunch-sdk";
+import { AgentLaunchClient } from '@fetchai/agent-launch-sdk';
 import { getBaseUrl, requireApiKey } from "./config.js";
 
 /**

--- a/packages/cli/src/lib/deploy-swarm.ts
+++ b/packages/cli/src/lib/deploy-swarm.ts
@@ -10,8 +10,8 @@ import {
   generateSwarmFromOrg,
   generateFromTemplate,
   getPreset,
-} from "agentlaunch-templates";
-import { deployAgent } from "agentlaunch-sdk";
+} from '@fetchai/agent-launch-templates';
+import { deployAgent } from '@fetchai/agent-launch-sdk';
 
 type SwarmConfig = ReturnType<typeof generateSwarmFromOrg>;
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-launch-mcp",
+  "name": "@fetchai/agent-launch-mcp",
   "version": "3.0.0",
   "description": "MCP server for AgentLaunch - create AI agent tokens via Claude Code",
   "type": "module",
@@ -23,8 +23,8 @@
   "dependencies": {
     "@cosmjs/crypto": "^0.32.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
-    "agentlaunch-sdk": "^0.3.0",
-    "agentlaunch-templates": "^1.0.0",
+    "@fetchai/agent-launch-sdk": "^0.3.0",
+    "@fetchai/agent-launch-templates": "^1.0.0",
     "bech32": "^2.0.0",
     "dotenv": "^17.3.1",
     "ethers": "^6.0.0"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -42,7 +42,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/fetchai/agent-launch-toolkit"
+    "url": "git+https://github.com/fetchai/agent-launch-toolkit.git"
   },
   "homepage": "https://agent-launch.ai",
   "bugs": {

--- a/packages/mcp/src/tools/agentverse.ts
+++ b/packages/mcp/src/tools/agentverse.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { deployAgent, updateAgent, buildOptimizationChecklist } from 'agentlaunch-sdk';
-import type { AgentverseDeployResult, AgentMetadata, OptimizationCheckItem } from 'agentlaunch-sdk';
+import { deployAgent, updateAgent, buildOptimizationChecklist } from '@fetchai/agent-launch-sdk';
+import type { AgentverseDeployResult, AgentMetadata, OptimizationCheckItem } from '@fetchai/agent-launch-sdk';
 
 /**
  * Validates that a file path is within the current working directory.

--- a/packages/mcp/src/tools/auth.ts
+++ b/packages/mcp/src/tools/auth.ts
@@ -4,8 +4,8 @@
  * W-14, W-15: Tools for authenticating with Agentverse using a wallet private key.
  */
 
-import { authenticateWithWallet, generateWalletAndAuthenticate, AgentLaunchClient } from 'agentlaunch-sdk';
-import type { WalletAuthResult, GenerateWalletResult, MyAgentsResponse } from 'agentlaunch-sdk';
+import { authenticateWithWallet, generateWalletAndAuthenticate, AgentLaunchClient } from '@fetchai/agent-launch-sdk';
+import type { WalletAuthResult, GenerateWalletResult, MyAgentsResponse } from '@fetchai/agent-launch-sdk';
 
 // ---------------------------------------------------------------------------
 // Return types

--- a/packages/mcp/src/tools/calculate.ts
+++ b/packages/mcp/src/tools/calculate.ts
@@ -1,5 +1,5 @@
-import { AgentLaunchClient } from 'agentlaunch-sdk';
-import type { CalculateBuyResponse, CalculateSellResponse } from 'agentlaunch-sdk';
+import { AgentLaunchClient } from '@fetchai/agent-launch-sdk';
+import type { CalculateBuyResponse, CalculateSellResponse } from '@fetchai/agent-launch-sdk';
 
 const client = new AgentLaunchClient();
 

--- a/packages/mcp/src/tools/comments.ts
+++ b/packages/mcp/src/tools/comments.ts
@@ -1,5 +1,5 @@
-import { AgentLaunchClient } from 'agentlaunch-sdk';
-import type { Comment } from 'agentlaunch-sdk';
+import { AgentLaunchClient } from '@fetchai/agent-launch-sdk';
+import type { Comment } from '@fetchai/agent-launch-sdk';
 
 const client = new AgentLaunchClient();
 

--- a/packages/mcp/src/tools/commerce.ts
+++ b/packages/mcp/src/tools/commerce.ts
@@ -1,5 +1,5 @@
-import { deployAgent, resolveApiKey, setSecret } from 'agentlaunch-sdk';
-import { generateFromTemplate } from 'agentlaunch-templates';
+import { deployAgent, resolveApiKey, setSecret } from '@fetchai/agent-launch-sdk';
+import { generateFromTemplate } from '@fetchai/agent-launch-templates';
 
 // ---------------------------------------------------------------------------
 // Marketing Team preset definitions (expected interface from agentlaunch-templates)
@@ -116,7 +116,7 @@ const FALLBACK_PRESETS: Record<string, Preset> = {
  */
 async function resolvePreset(presetName: string): Promise<Preset> {
   try {
-    const templates = await import('agentlaunch-templates') as unknown as Record<string, unknown>;
+    const templates = await import('@fetchai/agent-launch-templates') as unknown as Record<string, unknown>;
     if (typeof templates.getPreset === 'function') {
       const preset = (templates.getPreset as (name: string) => Preset | null)(presetName);
       if (preset) return preset;
@@ -208,7 +208,7 @@ export async function checkAgentCommerce(args: {
 
   // Try SDK first (may not exist yet)
   try {
-    const sdk = await import('agentlaunch-sdk') as unknown as Record<string, unknown>;
+    const sdk = await import('@fetchai/agent-launch-sdk') as unknown as Record<string, unknown>;
     if (typeof sdk.getAgentCommerceStatus === 'function') {
       return await (sdk.getAgentCommerceStatus as (addr: string) => Promise<Record<string, unknown>>)(args.address);
     }
@@ -255,7 +255,7 @@ export async function networkStatus(args: {
 
   // Try SDK first (may not exist yet)
   try {
-    const sdk = await import('agentlaunch-sdk') as unknown as Record<string, unknown>;
+    const sdk = await import('@fetchai/agent-launch-sdk') as unknown as Record<string, unknown>;
     if (typeof sdk.getNetworkGDP === 'function') {
       return await (sdk.getNetworkGDP as (addrs: string[]) => Promise<Record<string, unknown>>)(args.addresses);
     }

--- a/packages/mcp/src/tools/connect/deploy.ts
+++ b/packages/mcp/src/tools/connect/deploy.ts
@@ -7,8 +7,8 @@
 // running a full Python agent.
 // ---------------------------------------------------------------------------
 
-import { connectAgent as sdkConnectAgent } from 'agentlaunch-sdk';
-import type { ConnectConfig } from 'agentlaunch-sdk';
+import { connectAgent as sdkConnectAgent } from '@fetchai/agent-launch-sdk';
+import type { ConnectConfig } from '@fetchai/agent-launch-sdk';
 
 // ---------------------------------------------------------------------------
 // Return type

--- a/packages/mcp/src/tools/connect/status.ts
+++ b/packages/mcp/src/tools/connect/status.ts
@@ -5,7 +5,7 @@
  *                        for a given agent1q... address.
  */
 
-import { connectionStatus as sdkConnectionStatus } from 'agentlaunch-sdk';
+import { connectionStatus as sdkConnectionStatus } from '@fetchai/agent-launch-sdk';
 
 // ---------------------------------------------------------------------------
 // Return type

--- a/packages/mcp/src/tools/connect/update.ts
+++ b/packages/mcp/src/tools/connect/update.ts
@@ -5,8 +5,8 @@
  * credentials) that a connected agent forwards requests to.
  */
 
-import { updateConnection as sdkUpdateConnection } from 'agentlaunch-sdk';
-import type { ConnectConfig } from 'agentlaunch-sdk';
+import { updateConnection as sdkUpdateConnection } from '@fetchai/agent-launch-sdk';
+import type { ConnectConfig } from '@fetchai/agent-launch-sdk';
 
 // ---------------------------------------------------------------------------
 // Return type

--- a/packages/mcp/src/tools/custodial.ts
+++ b/packages/mcp/src/tools/custodial.ts
@@ -13,8 +13,8 @@
  * Tools: get_agent_wallet, buy_token, sell_token
  */
 
-import { getWallet, executeBuy, executeSell } from 'agentlaunch-sdk';
-import type { WalletInfoResponse, CustodialBuyResult, CustodialSellResult } from 'agentlaunch-sdk';
+import { getWallet, executeBuy, executeSell } from '@fetchai/agent-launch-sdk';
+import type { WalletInfoResponse, CustodialBuyResult, CustodialSellResult } from '@fetchai/agent-launch-sdk';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/mcp/src/tools/discovery.ts
+++ b/packages/mcp/src/tools/discovery.ts
@@ -1,5 +1,5 @@
-import { AgentLaunchClient, listTokens as sdkListTokens, getToken as sdkGetToken } from 'agentlaunch-sdk';
-import type { TokenListResponse, Token, PlatformStats } from 'agentlaunch-sdk';
+import { AgentLaunchClient, listTokens as sdkListTokens, getToken as sdkGetToken } from '@fetchai/agent-launch-sdk';
+import type { TokenListResponse, Token, PlatformStats } from '@fetchai/agent-launch-sdk';
 
 const client = new AgentLaunchClient();
 

--- a/packages/mcp/src/tools/handoff.ts
+++ b/packages/mcp/src/tools/handoff.ts
@@ -1,5 +1,5 @@
-import { AgentLaunchClient, getFrontendUrl, getToken } from 'agentlaunch-sdk';
-import type { Token } from 'agentlaunch-sdk';
+import { AgentLaunchClient, getFrontendUrl, getToken } from '@fetchai/agent-launch-sdk';
+import type { Token } from '@fetchai/agent-launch-sdk';
 
 const client = new AgentLaunchClient();
 const FRONTEND_BASE_URL = getFrontendUrl();

--- a/packages/mcp/src/tools/payments.ts
+++ b/packages/mcp/src/tools/payments.ts
@@ -14,7 +14,7 @@ import {
   checkAllowance,
   createSpendingLimitHandoff,
   generateFiatOnrampLink,
-} from 'agentlaunch-sdk';
+} from '@fetchai/agent-launch-sdk';
 import type {
   PaymentToken,
   Invoice,
@@ -22,7 +22,7 @@ import type {
   SpendingLimit,
   FiatOnrampLink,
   TokenAmount,
-} from 'agentlaunch-sdk';
+} from '@fetchai/agent-launch-sdk';
 
 // ---------------------------------------------------------------------------
 // Spending safety

--- a/packages/mcp/src/tools/scaffold.ts
+++ b/packages/mcp/src/tools/scaffold.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { generateFromTemplate, generateOrgTemplate, generateSwarmFromOrg, summarizeSwarm } from 'agentlaunch-templates';
-import type { OrgChart, SwarmConfig } from 'agentlaunch-templates';
+import { generateFromTemplate, generateOrgTemplate, generateSwarmFromOrg, summarizeSwarm } from '@fetchai/agent-launch-templates';
+import type { OrgChart, SwarmConfig } from '@fetchai/agent-launch-templates';
 
 /**
  * Validates that a directory path is within the current working directory.
@@ -191,7 +191,7 @@ export async function scaffoldSwarm(args: {
 
   if (presetName !== 'custom') {
     try {
-      const templates = await import('agentlaunch-templates') as unknown as Record<string, unknown>;
+      const templates = await import('@fetchai/agent-launch-templates') as unknown as Record<string, unknown>;
       if (typeof templates.getPreset === 'function') {
         const preset = (templates.getPreset as (name: string) => Preset | null)(presetName);
         if (preset) {
@@ -416,7 +416,7 @@ ${agentRows}
 
       let generated;
       try {
-        const templates = await import('agentlaunch-templates') as unknown as Record<string, unknown>;
+        const templates = await import('@fetchai/agent-launch-templates') as unknown as Record<string, unknown>;
         const preset = typeof templates.getPreset === 'function'
           ? (templates.getPreset as (name: string) => Preset | null)(agent.role)
           : null;

--- a/packages/mcp/src/tools/skill.ts
+++ b/packages/mcp/src/tools/skill.ts
@@ -61,8 +61,8 @@ function parseSkillToJson(markdown: string): object {
       "Tokenize any AI agent — deploy to Agentverse, create bonding curve tokens, build agent economies",
     phases,
     tools: {
-      sdk: "agentlaunch-sdk",
-      cli: "agentlaunch",
+      sdk: "@fetchai/agent-launch-sdk",
+      cli: "@fetchai/agent-launch-cli",
       mcp: "agent-launch-mcp",
     },
     auth: {

--- a/packages/mcp/src/tools/tokenize.ts
+++ b/packages/mcp/src/tools/tokenize.ts
@@ -1,5 +1,5 @@
-import { AgentLaunchClient, getFrontendUrl, deployAgent, resolveApiKey } from 'agentlaunch-sdk';
-import { generateFromTemplate } from 'agentlaunch-templates';
+import { AgentLaunchClient, getFrontendUrl, deployAgent, resolveApiKey } from '@fetchai/agent-launch-sdk';
+import { generateFromTemplate } from '@fetchai/agent-launch-templates';
 
 const client = new AgentLaunchClient();
 const FRONTEND_BASE_URL = getFrontendUrl();

--- a/packages/mcp/src/tools/trading.ts
+++ b/packages/mcp/src/tools/trading.ts
@@ -11,8 +11,8 @@ import {
   calculateBuy,
   calculateSell,
   DEFAULT_SLIPPAGE_PERCENT,
-} from 'agentlaunch-sdk';
-import type { BuyResult, SellResult, WalletBalances, CalculateBuyResponse, CalculateSellResponse } from 'agentlaunch-sdk';
+} from '@fetchai/agent-launch-sdk';
+import type { BuyResult, SellResult, WalletBalances, CalculateBuyResponse, CalculateSellResponse } from '@fetchai/agent-launch-sdk';
 
 /** Buy tokens on a bonding curve. With dryRun=true, returns a preview only. */
 export async function buyTokensTool(args: {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -66,7 +66,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fetchai/agent-launch-toolkit"
+    "url": "git+https://github.com/fetchai/agent-launch-toolkit.git"
   },
   "homepage": "https://agent-launch.ai",
   "bugs": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentlaunch-sdk",
+  "name": "@fetchai/agent-launch-sdk",
   "version": "0.3.0",
   "description": "TypeScript SDK for the AgentLaunch platform — create AI agent tokens, query market data, and generate handoff links",
   "type": "module",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentlaunch-templates",
+  "name": "@fetchai/agent-launch-templates",
   "version": "1.0.0",
   "description": "Agent code templates for the AgentLaunch platform",
   "type": "module",

--- a/packages/templates/src/__tests__/build.test.ts
+++ b/packages/templates/src/__tests__/build.test.ts
@@ -103,7 +103,7 @@ describe('Build verification — templates package', () => {
 
 describe('Build verification — SDK package', () => {
   it('exports AgentLaunchClient', async () => {
-    const mod = await import('agentlaunch-sdk');
+    const mod = await import('@fetchai/agent-launch-sdk');
     assert.ok(
       typeof mod.AgentLaunchClient === 'function',
       'should export AgentLaunchClient',
@@ -111,7 +111,7 @@ describe('Build verification — SDK package', () => {
   });
 
   it('exports AgentLaunch fluent wrapper', async () => {
-    const mod = await import('agentlaunch-sdk');
+    const mod = await import('@fetchai/agent-launch-sdk');
     assert.ok(
       typeof mod.AgentLaunch === 'function',
       'should export AgentLaunch',
@@ -120,7 +120,7 @@ describe('Build verification — SDK package', () => {
 
   it('exports storage functions', async () => {
     // Cast to Record to access properties that will be added by the storage module agent
-    const mod = await import('agentlaunch-sdk') as unknown as Record<string, unknown>;
+    const mod = await import('@fetchai/agent-launch-sdk') as unknown as Record<string, unknown>;
     assert.ok(typeof mod['listStorage'] === 'function', 'should export listStorage');
     assert.ok(typeof mod['getStorage'] === 'function', 'should export getStorage');
     assert.ok(typeof mod['putStorage'] === 'function', 'should export putStorage');
@@ -129,7 +129,7 @@ describe('Build verification — SDK package', () => {
 
   it('exports commerce functions', async () => {
     // Cast to Record to access properties that will be added by the commerce module agent
-    const mod = await import('agentlaunch-sdk') as unknown as Record<string, unknown>;
+    const mod = await import('@fetchai/agent-launch-sdk') as unknown as Record<string, unknown>;
     assert.ok(typeof mod['getAgentRevenue'] === 'function', 'should export getAgentRevenue');
     assert.ok(typeof mod['getPricingTable'] === 'function', 'should export getPricingTable');
     assert.ok(typeof mod['getAgentCommerceStatus'] === 'function', 'should export getAgentCommerceStatus');
@@ -137,7 +137,7 @@ describe('Build verification — SDK package', () => {
   });
 
   it('AgentLaunch fluent wrapper creates all namespaces', async () => {
-    const { AgentLaunch } = await import('agentlaunch-sdk');
+    const { AgentLaunch } = await import('@fetchai/agent-launch-sdk');
     const al = new AgentLaunch({ apiKey: 'test-key' });
     assert.ok(al.tokens, 'should have tokens namespace');
     assert.ok(al.market, 'should have market namespace');


### PR DESCRIPTION
## Summary

Renames all 4 packages from their legacy unscoped names to the `@fetchai/` scoped names for npm publication.

### Changes
- `agentlaunch-sdk` → `@fetchai/agent-launch-sdk`
- `agentlaunch` → `@fetchai/agent-launch-cli`
- `agent-launch-mcp` → `@fetchai/agent-launch-mcp`
- `agentlaunch-templates` → `@fetchai/agent-launch-templates`

### What was updated
- All 4 `package.json` name fields
- Cross-package `dependencies` in `cli/package.json` and `mcp/package.json`
- All source `import` statements across CLI (25 files) and MCP (16 files)
- Dynamic `import()` calls in `commerce.ts` and `scaffold.ts`
- Templates test file dynamic imports

### Validation
- All 4 packages build cleanly (TypeScript no errors)
- All 4 dry-run `npm publish --access public` pass
- Workspace symlinks correctly created under `node_modules/@fetchai/`

### Why @fetchai/ scope?
The legacy unscoped packages (`agentlaunch-sdk` etc.) are owned by `oneie` on npm. The `web3guru888` account (our npm account) does not have publish rights to those packages. Publishing under `@fetchai/` scope creates new packages under our org with the correct branding.

### Still needed
- Robin to provide an **Automation** type npm token (current token is Publish type, requires 2FA OTP)
- Confirm `web3guru888` has publisher access to `@fetchai` org on npmjs.com

Once token is updated in `/shared/agentlaunch-env.sh`, publish is:
```bash
cd packages/templates && npm publish --access public
cd ../sdk && npm publish --access public  
cd ../mcp && npm publish --access public
cd ../cli && npm publish --access public
```