### PR TITLE
docs: update package names to @fetchai scoped names, fix npx commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 - Tokenize them on a bonding curve — anyone can buy in, price rises with demand
 
 ```bash
-npx agentlaunch
+# Install CLI globally
+npm install -g @fetchai/agent-launch-cli
+
+# Then run the interactive wizard
+agentlaunch
 ```
 
 ---
@@ -123,7 +127,7 @@ Your OpenClaw agent now understands monetization, token launches, and cross-agen
 **Claude Code / Cursor** (MCP):
 
 ```bash
-npx agent-launch-mcp
+npx @fetchai/agent-launch-mcp
 ```
 
 30 tools for tokenization, trading, and commerce.
@@ -148,26 +152,27 @@ See the [Connect guide](./docs/connect.md) for LangChain, CrewAI, AutoGPT, and c
 ### CLI Commands
 
 ```bash
-npx agentlaunch                                     # Interactive (prompts for name, deploys by default)
-npx agentlaunch my-bot                              # Create agent named "my-bot"
-npx agentlaunch my-bot --local                      # Scaffold only, no deploy
-npx agentlaunch deploy                              # Deploy agent.py to Agentverse
-npx agentlaunch optimize agent1q...                 # Update README/description for ranking
-npx agentlaunch tokenize --agent agent1q... \
+# First: npm install -g @fetchai/agent-launch-cli
+agentlaunch                                         # Interactive (prompts for name, deploys by default)
+agentlaunch my-bot                                  # Create agent named "my-bot"
+agentlaunch my-bot --local                          # Scaffold only, no deploy
+agentlaunch deploy                                  # Deploy agent.py to Agentverse
+agentlaunch optimize agent1q...                     # Update README/description for ranking
+agentlaunch tokenize --agent agent1q... \
   --name "MyBot" --symbol MBOT                      # Create token + handoff link
-npx agentlaunch list                                # Browse tokens
-npx agentlaunch status 0x...                        # Check price/progress
-npx agentlaunch comments 0x...                      # List/post token comments
-npx agentlaunch holders 0x...                       # Token holder distribution
-npx agentlaunch buy 0x... --amount 10                # Buy tokens with 10 FET
-npx agentlaunch sell 0x... --amount 50000            # Sell 50000 tokens for FET
-npx agentlaunch claim 0x...                          # Claim 200 TFET + 0.005 tBNB (up to 3x)
-npx agentlaunch init                                 # Install toolkit into existing project
-npx agentlaunch wallet balances                      # Show FET + USDC + BNB balances
-npx agentlaunch wallet send USDC 0x... 10            # Transfer tokens
-npx agentlaunch wallet delegate FET 100 --spender 0x... # Spending approval link
-npx agentlaunch pay 0x... 10 --token USDC            # Direct token payment
-npx agentlaunch config set-key av-xxx               # Store API key
+agentlaunch list                                    # Browse tokens
+agentlaunch status 0x...                            # Check price/progress
+agentlaunch comments 0x...                          # List/post token comments
+agentlaunch holders 0x...                           # Token holder distribution
+agentlaunch buy 0x... --amount 10                   # Buy tokens with 10 FET
+agentlaunch sell 0x... --amount 50000               # Sell 50000 tokens for FET
+agentlaunch claim 0x...                             # Claim 200 TFET + 0.005 tBNB (up to 3x)
+agentlaunch init                                    # Install toolkit into existing project
+agentlaunch wallet balances                         # Show FET + USDC + BNB balances
+agentlaunch wallet send USDC 0x... 10               # Transfer tokens
+agentlaunch wallet delegate FET 100 --spender 0x... # Spending approval link
+agentlaunch pay 0x... 10 --token USDC               # Direct token payment
+agentlaunch config set-key av-xxx                   # Store API key
 ```
 
 All commands support `--json` for machine-readable output.
@@ -175,7 +180,7 @@ All commands support `--json` for machine-readable output.
 ### SDK (TypeScript)
 
 ```typescript
-import { AgentLaunch, calculateBuy } from 'agentlaunch-sdk';
+import { AgentLaunch, calculateBuy } from '@fetchai/agent-launch-sdk';
 
 const al = new AgentLaunch();
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -44,7 +44,7 @@ Created docs/TODO.md with 20 tasks across 5 phases.
 # Execute tasks one by one
 > /grow
 Executing L-1: Deploy the swarm...
-Running: npx agentlaunch create → Marketing Team
+Running: agentlaunch create → Marketing Team
 KPI: All 7 running ✓
 Task L-1 complete.
 
@@ -80,8 +80,9 @@ Dev URLs (Cloud Run) will be used when `AGENT_LAUNCH_ENV=dev` is set.
 
 1. **Claude Code** installed ([claude.ai/code](https://claude.ai/code))
 2. **Node.js 18+** installed
-3. **Agentverse API key** — get one free at [agentverse.ai/profile/api-keys](https://agentverse.ai/profile/api-keys)
-4. **BSC wallet with ~125 FET** — needed only at the final deploy step (MetaMask, Rainbow, etc.)
+3. **CLI installed globally** — `npm install -g @fetchai/agent-launch-cli`
+4. **Agentverse API key** — get one free at [agentverse.ai/profile/api-keys](https://agentverse.ai/profile/api-keys)
+5. **BSC wallet with ~125 FET** — needed only at the final deploy step (MetaMask, Rainbow, etc.)
 
 ---
 
@@ -196,7 +197,7 @@ and alerts when price moves more than 5%
 Or use the CLI directly:
 
 ```bash
-npx agentlaunch scaffold FETTracker --template price-monitor
+agentlaunch scaffold FETTracker --template price-monitor
 ```
 
 This creates `agent.py` with the Agentverse Chat Protocol boilerplate. Review and customize it.
@@ -214,7 +215,7 @@ Deploy my agent to Agentverse
 Or use the CLI:
 
 ```bash
-npx agentlaunch deploy agent.py --name "FET Tracker"
+agentlaunch deploy agent.py --name "FET Tracker"
 ```
 
 Claude uses the `deploy_to_agentverse` MCP tool. It will:
@@ -237,7 +238,7 @@ Tokenize my agent as $FTRK on BSC mainnet
 Or use the CLI:
 
 ```bash
-npx agentlaunch tokenize --agent agent1q... --name "FET Tracker" --symbol FTRK --chain 56
+agentlaunch tokenize --agent agent1q... --name "FET Tracker" --symbol FTRK --chain 56
 ```
 
 Claude calls `create_token_record` and returns:
@@ -332,21 +333,21 @@ You (in Claude Code)          Agentverse              AgentLaunch            Blo
 
 ```bash
 # Full interactive wizard
-npx agentlaunch create
+agentlaunch create
 
 # Or step by step
-npx agentlaunch scaffold MyAgent --template research
-npx agentlaunch deploy agent.py --name "My Agent"
-npx agentlaunch tokenize --agent agent1q... --name "My Agent" --symbol MAGNT
-npx agentlaunch list
-npx agentlaunch status 0x...
-npx agentlaunch holders 0x...
+agentlaunch scaffold MyAgent --template research
+agentlaunch deploy agent.py --name "My Agent"
+agentlaunch tokenize --agent agent1q... --name "My Agent" --symbol MAGNT
+agentlaunch list
+agentlaunch status 0x...
+agentlaunch holders 0x...
 ```
 
 ### Pure SDK (TypeScript)
 
 ```typescript
-import { AgentLaunch } from 'agentlaunch-sdk';
+import { AgentLaunch } from '@fetchai/agent-launch-sdk';
 
 const al = new AgentLaunch({ apiKey: process.env.AGENTVERSE_API_KEY });
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,10 +6,10 @@ Command-line interface for [AgentLaunch](https://agent-launch.ai) — one comman
 
 ```bash
 # Global install (recommended for interactive use)
-npm install -g agentlaunch
+npm install -g @fetchai/agent-launch-cli
 
 # Or run without installing
-npx agentlaunch
+npx @fetchai/agent-launch-cli
 ```
 
 Requires Node.js >= 18.
@@ -97,16 +97,16 @@ Create an agent, deploy it to Agentverse, and open Claude Code — all in one st
 
 ```bash
 # Interactive — prompts for name, description, and API key
-npx agentlaunch
+npx @fetchai/agent-launch-cli
 
 # With name — skips the name prompt
-npx agentlaunch my-agent
+npx @fetchai/agent-launch-cli my-agent
 
 # Scaffold only (no deploy)
-npx agentlaunch my-agent --local
+npx @fetchai/agent-launch-cli my-agent --local
 
 # Machine-readable output for AI agents (no prompts, JSON only)
-npx agentlaunch my-agent --json
+npx @fetchai/agent-launch-cli my-agent --json
 ```
 
 **Options:**
@@ -505,7 +505,8 @@ agentlaunch config set-url <url>      # Set custom API base URL
 ### Build and deploy a new agent
 
 ```bash
-npx agentlaunch my-bot
+# After: npm install -g @fetchai/agent-launch-cli
+agentlaunch my-bot
 # -> Scaffolds, deploys, opens editor
 # Edit agent.py, then:
 agentlaunch optimize agent1q...
@@ -572,7 +573,7 @@ Every command supports `--json`. In JSON mode:
 **Example — AI agent creates and deploys programmatically:**
 
 ```bash
-RESULT=$(npx agentlaunch my-analyst --json)
+RESULT=$(agentlaunch my-analyst --json)
 
 ADDRESS=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['agentAddress'])")
 echo "Agent deployed: $ADDRESS"
@@ -611,8 +612,8 @@ These values are enforced by the deployed smart contracts and cannot be changed 
 
 ## Cross-References
 
-- **SDK:** [`agentlaunch-sdk`](../sdk/README.md) — TypeScript client this CLI wraps
-- **MCP Server:** [`agent-launch-mcp`](../mcp/README.md) — Same operations as Claude Code tools
+- **SDK:** [`@fetchai/agent-launch-sdk`](../sdk/README.md) — TypeScript client this CLI wraps
+- **MCP Server:** [`@fetchai/agent-launch-mcp`](../mcp/README.md) — Same operations as Claude Code tools
 - **Templates:** [`agentlaunch-templates`](../templates/README.md) — Agent blueprints
 
 ## Resources

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@
 
 This MCP server connects Claude Code (and any MCP-compatible client) to [Agent-Launch](https://agent-launch.ai) — the launchpad for AI agent tokens on Fetch.ai. Create tokens, trade on bonding curves, manage multi-token payments, scaffold agents, and generate deployment links without leaving your terminal.
 
-**Version:** 2.3.3 | **npm:** [agent-launch-mcp](https://www.npmjs.com/package/agent-launch-mcp)
+**Version:** 3.0.0 | **npm:** [@fetchai/agent-launch-mcp](https://www.npmjs.com/package/@fetchai/agent-launch-mcp)
 
 ---
 
@@ -32,13 +32,13 @@ This MCP server connects Claude Code (and any MCP-compatible client) to [Agent-L
 Run on-demand with npx (no global install needed):
 
 ```bash
-npx agent-launch-mcp
+npx @fetchai/agent-launch-mcp
 ```
 
 Or pin to latest:
 
 ```bash
-npx -y agent-launch-mcp@latest
+npx -y @fetchai/agent-launch-mcp@latest
 ```
 
 ---
@@ -52,7 +52,7 @@ npx -y agent-launch-mcp@latest
   "mcpServers": {
     "agent-launch": {
       "command": "npx",
-      "args": ["-y", "agent-launch-mcp@latest"],
+      "args": ["-y", "@fetchai/agent-launch-mcp@latest"],
       "env": { "AGENT_LAUNCH_API_KEY": "your_agentverse_api_key" }
     }
   }
@@ -66,7 +66,7 @@ npx -y agent-launch-mcp@latest
   "mcpServers": {
     "agent-launch": {
       "command": "npx",
-      "args": ["-y", "agent-launch-mcp@latest"],
+      "args": ["-y", "@fetchai/agent-launch-mcp@latest"],
       "env": { "AGENT_LAUNCH_API_KEY": "your_agentverse_api_key" }
     }
   }
@@ -419,7 +419,7 @@ Set `WALLET_PRIVATE_KEY` in your MCP server env config for trading and payment o
 
 ## Cross-References
 
-- **SDK:** [`agentlaunch-sdk`](../sdk/README.md) — TypeScript functions this MCP server wraps
+- **SDK:** [`@fetchai/agent-launch-sdk`](../sdk/README.md) — TypeScript functions this MCP server wraps
 - **CLI:** [`agentlaunch`](../cli/README.md) — Same operations as shell commands
 
 ## Links
@@ -429,7 +429,7 @@ Set `WALLET_PRIVATE_KEY` in your MCP server env config for trading and payment o
 - **OpenAPI spec:** [agent-launch.ai/docs/openapi](https://agent-launch.ai/docs/openapi)
 - **Skill manifest:** [agent-launch.ai/skill.md](https://agent-launch.ai/skill.md)
 - **Get API key:** [agentverse.ai/profile/api-keys](https://agentverse.ai/profile/api-keys)
-- **npm package:** [npmjs.com/package/agent-launch-mcp](https://www.npmjs.com/package/agent-launch-mcp)
+- **npm package:** [npmjs.com/package/@fetchai/agent-launch-mcp](https://www.npmjs.com/package/@fetchai/agent-launch-mcp)
 
 ---
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,8 +1,8 @@
-# agentlaunch-sdk
+# @fetchai/agent-launch-sdk
 
-[![npm version](https://img.shields.io/npm/v/agentlaunch-sdk.svg)](https://www.npmjs.com/package/agentlaunch-sdk)
+[![npm version](https://img.shields.io/npm/v/@fetchai/agent-launch-sdk.svg)](https://www.npmjs.com/package/@fetchai/agent-launch-sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node.js Version](https://img.shields.io/node/v/agentlaunch-sdk.svg)](https://nodejs.org)
+[![Node.js Version](https://img.shields.io/node/v/@fetchai/agent-launch-sdk.svg)](https://nodejs.org)
 
 TypeScript SDK for the [AgentLaunch](https://agent-launch.ai) platform — create AI agent tokens, trade on bonding curves, accept multi-token payments, manage invoices, and monitor agent economies.
 
@@ -11,7 +11,7 @@ No external runtime dependencies. Uses the global `fetch()` available in Node.js
 ## Install
 
 ```bash
-npm install agentlaunch-sdk
+npm install @fetchai/agent-launch-sdk
 
 # For on-chain trading and payments (optional)
 npm install ethers@^6
@@ -41,7 +41,7 @@ npm install ethers@^6
 ## Quick Start
 
 ```typescript
-import { tokenize, generateDeployLink } from 'agentlaunch-sdk';
+import { tokenize, generateDeployLink } from '@fetchai/agent-launch-sdk';
 
 // 1. Create a pending token record
 const { data } = await tokenize({
@@ -68,7 +68,7 @@ export AGENTVERSE_API_KEY=av-xxxxxxxxxxxxxxxx
 **Option 2 — Pass directly to the client:**
 
 ```typescript
-import { AgentLaunchClient } from 'agentlaunch-sdk';
+import { AgentLaunchClient } from '@fetchai/agent-launch-sdk';
 
 const client = new AgentLaunchClient({ apiKey: 'av-xxxxxxxxxxxxxxxx' });
 ```
@@ -84,7 +84,7 @@ const client = new AgentLaunchClient({ apiKey: 'av-xxxxxxxxxxxxxxxx' });
 Create a pending token record for an Agentverse agent.
 
 ```typescript
-import { tokenize } from 'agentlaunch-sdk';
+import { tokenize } from '@fetchai/agent-launch-sdk';
 
 const { data } = await tokenize({
   agentAddress: 'agent1qf8xfhsc8hg4g5l0nhtj...',  // required
@@ -124,7 +124,7 @@ console.log(data.status);        // 'pending_deployment'
 Fetch a single token by its deployed contract address.
 
 ```typescript
-import { getToken } from 'agentlaunch-sdk';
+import { getToken } from '@fetchai/agent-launch-sdk';
 
 const token = await getToken('0xAbCd...');
 console.log(token.price);       // '0.000012' (FET)
@@ -138,7 +138,7 @@ console.log(token.listed);      // false
 List tokens with optional filtering and pagination.
 
 ```typescript
-import { listTokens } from 'agentlaunch-sdk';
+import { listTokens } from '@fetchai/agent-launch-sdk';
 
 const { tokens, total } = await listTokens({
   page: 1,
@@ -161,7 +161,7 @@ Direct buy/sell execution on bonding curve contracts. Requires `ethers@^6` and `
 Buy tokens on the bonding curve. Handles FET approval automatically.
 
 ```typescript
-import { buyTokens } from 'agentlaunch-sdk';
+import { buyTokens } from '@fetchai/agent-launch-sdk';
 
 const result = await buyTokens('0xAbCd...', '10', {
   chainId: 56,        // BSC Mainnet (default) — use 97 for testnet
@@ -181,7 +181,7 @@ console.log(result.blockNumber);     // 12345678
 Sell tokens back to the bonding curve for FET.
 
 ```typescript
-import { sellTokens } from 'agentlaunch-sdk';
+import { sellTokens } from '@fetchai/agent-launch-sdk';
 
 const result = await sellTokens('0xAbCd...', '500000');
 
@@ -196,7 +196,7 @@ console.log(result.priceImpact);  // 1.2
 Query BNB, FET, and token balances for the configured wallet.
 
 ```typescript
-import { getWalletBalances } from 'agentlaunch-sdk';
+import { getWalletBalances } from '@fetchai/agent-launch-sdk';
 
 const balances = await getWalletBalances('0xAbCd...');
 
@@ -212,7 +212,7 @@ console.log(balances.chainId);       // 56
 Get the balance of any ERC-20 token for any wallet.
 
 ```typescript
-import { getERC20Balance } from 'agentlaunch-sdk';
+import { getERC20Balance } from '@fetchai/agent-launch-sdk';
 
 const balance = await getERC20Balance(
   '0x304ddf3eE068c53514f782e2341B71A80c8aE3C7', // FET on BSC Testnet
@@ -226,7 +226,7 @@ console.log(balance); // '150.0'
 Approve an ERC-20 spender (for delegation or spending limits).
 
 ```typescript
-import { approveERC20 } from 'agentlaunch-sdk';
+import { approveERC20 } from '@fetchai/agent-launch-sdk';
 
 const txHash = await approveERC20(
   '0xFETAddress...',
@@ -240,7 +240,7 @@ const txHash = await approveERC20(
 Check how much a spender can spend on behalf of an owner.
 
 ```typescript
-import { getAllowance } from 'agentlaunch-sdk';
+import { getAllowance } from '@fetchai/agent-launch-sdk';
 
 const allowance = await getAllowance(
   '0xFETAddress...',
@@ -255,7 +255,7 @@ console.log(allowance); // '100.0'
 Transfer tokens from an owner to a recipient using prior approval.
 
 ```typescript
-import { transferFromERC20 } from 'agentlaunch-sdk';
+import { transferFromERC20 } from '@fetchai/agent-launch-sdk';
 
 const { txHash, blockNumber } = await transferFromERC20(
   '0xFETAddress...',
@@ -292,7 +292,7 @@ Token registry, balance queries, transfers, and invoice management. Supports FET
 Registry of well-known token addresses per chain.
 
 ```typescript
-import { KNOWN_TOKENS, getPaymentToken, getTokensForChain } from 'agentlaunch-sdk';
+import { KNOWN_TOKENS, getPaymentToken, getTokensForChain } from '@fetchai/agent-launch-sdk';
 
 // Look up a token by symbol
 const fet = getPaymentToken('FET', 56);
@@ -319,7 +319,7 @@ const bscMainnetTokens = getTokensForChain(56); // [FET, USDC]
 Get the balance of any ERC-20 token for a wallet.
 
 ```typescript
-import { getTokenBalance } from 'agentlaunch-sdk';
+import { getTokenBalance } from '@fetchai/agent-launch-sdk';
 
 const balance = await getTokenBalance(
   '0xBd5df99ABe0E2b1e86BE5eC0039d1e24de28Fe87', // FET on BSC Mainnet
@@ -334,7 +334,7 @@ console.log(balance); // '150.0'
 Get BNB + multiple token balances in a single call.
 
 ```typescript
-import { getMultiTokenBalances } from 'agentlaunch-sdk';
+import { getMultiTokenBalances } from '@fetchai/agent-launch-sdk';
 
 // All known tokens on BSC Testnet
 const balances = await getMultiTokenBalances('0xMyWallet...');
@@ -351,7 +351,7 @@ const fetOnly = await getMultiTokenBalances('0xMyWallet...', ['FET'], 56);
 Transfer any ERC-20 token to a recipient.
 
 ```typescript
-import { transferToken } from 'agentlaunch-sdk';
+import { transferToken } from '@fetchai/agent-launch-sdk';
 
 const { txHash, blockNumber } = await transferToken(
   '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d', // USDC on BSC Mainnet
@@ -373,7 +373,7 @@ Create and manage payment invoices stored in Agentverse agent storage.
 Create an invoice in agent storage. Status starts as `pending`.
 
 ```typescript
-import { createInvoice } from 'agentlaunch-sdk';
+import { createInvoice } from '@fetchai/agent-launch-sdk';
 
 const invoice = await createInvoice('agent1q...', {
   id: 'inv-001',
@@ -392,7 +392,7 @@ console.log(invoice.createdAt); // '2026-03-04T...'
 Get a single invoice by ID.
 
 ```typescript
-import { getInvoice } from 'agentlaunch-sdk';
+import { getInvoice } from '@fetchai/agent-launch-sdk';
 
 const invoice = await getInvoice('agent1q...', 'inv-001');
 if (invoice) {
@@ -405,7 +405,7 @@ if (invoice) {
 List all invoices, optionally filtered by status.
 
 ```typescript
-import { listInvoices } from 'agentlaunch-sdk';
+import { listInvoices } from '@fetchai/agent-launch-sdk';
 
 const pending = await listInvoices('agent1q...', 'pending');
 console.log(`${pending.length} pending invoices`);
@@ -416,7 +416,7 @@ console.log(`${pending.length} pending invoices`);
 Update an invoice's status (e.g., mark as paid with a transaction hash).
 
 ```typescript
-import { updateInvoiceStatus } from 'agentlaunch-sdk';
+import { updateInvoiceStatus } from '@fetchai/agent-launch-sdk';
 
 const updated = await updateInvoiceStatus(
   'agent1q...',
@@ -439,7 +439,7 @@ Spending delegation via standard ERC-20 `approve()` / `transferFrom()`. No custo
 Check the on-chain ERC-20 allowance for a spender.
 
 ```typescript
-import { checkAllowance } from 'agentlaunch-sdk';
+import { checkAllowance } from '@fetchai/agent-launch-sdk';
 
 const limit = await checkAllowance(
   '0xBd5df99ABe0E2b1e86BE5eC0039d1e24de28Fe87', // FET on BSC Mainnet
@@ -457,7 +457,7 @@ console.log(limit.token);     // { symbol: 'FET', ... }
 Spend from a delegation using `transferFrom`. Requires prior `approve()`.
 
 ```typescript
-import { spendFromDelegation } from 'agentlaunch-sdk';
+import { spendFromDelegation } from '@fetchai/agent-launch-sdk';
 
 const { txHash, blockNumber } = await spendFromDelegation(
   '0x304ddf3eE068c53514f782e2341B71A80c8aE3C7', // FET
@@ -472,7 +472,7 @@ const { txHash, blockNumber } = await spendFromDelegation(
 Generate a handoff link for a human to approve a spending limit.
 
 ```typescript
-import { createSpendingLimitHandoff } from 'agentlaunch-sdk';
+import { createSpendingLimitHandoff } from '@fetchai/agent-launch-sdk';
 
 const link = createSpendingLimitHandoff(
   { tokenSymbol: 'FET', amount: '100', chainId: 56 },
@@ -486,7 +486,7 @@ const link = createSpendingLimitHandoff(
 Record a delegation in agent storage for tracking.
 
 ```typescript
-import { recordDelegation } from 'agentlaunch-sdk';
+import { recordDelegation } from '@fetchai/agent-launch-sdk';
 
 await recordDelegation('agent1q...', {
   owner: '0xOwner...',
@@ -503,7 +503,7 @@ await recordDelegation('agent1q...', {
 List all recorded delegations for an agent.
 
 ```typescript
-import { listDelegations } from 'agentlaunch-sdk';
+import { listDelegations } from '@fetchai/agent-launch-sdk';
 
 const delegations = await listDelegations('agent1q...');
 for (const d of delegations) {
@@ -522,7 +522,7 @@ Read commerce data (revenue, pricing, GDP) from agent storage. Works with swarm-
 Read revenue data for an agent.
 
 ```typescript
-import { getAgentRevenue } from 'agentlaunch-sdk';
+import { getAgentRevenue } from '@fetchai/agent-launch-sdk';
 
 const revenue = await getAgentRevenue('agent1q...');
 console.log(`Net revenue: ${revenue.netRevenue} atestfet`);
@@ -535,7 +535,7 @@ console.log(`Daily: ${JSON.stringify(revenue.dailySummary)}`);
 Read the per-service pricing table.
 
 ```typescript
-import { getPricingTable } from 'agentlaunch-sdk';
+import { getPricingTable } from '@fetchai/agent-launch-sdk';
 
 const pricing = await getPricingTable('agent1q...');
 for (const p of pricing) {
@@ -548,7 +548,7 @@ for (const p of pricing) {
 Full commerce dashboard for an agent — revenue, pricing, balance, tier, token data, invoices, and delegations combined.
 
 ```typescript
-import { getAgentCommerceStatus } from 'agentlaunch-sdk';
+import { getAgentCommerceStatus } from '@fetchai/agent-launch-sdk';
 
 const status = await getAgentCommerceStatus('agent1q...');
 console.log(`Revenue: ${status.revenue.netRevenue} atestfet`);
@@ -565,7 +565,7 @@ console.log(`Delegations: ${status.delegations}`);
 Aggregate GDP across a set of agents.
 
 ```typescript
-import { getNetworkGDP } from 'agentlaunch-sdk';
+import { getNetworkGDP } from '@fetchai/agent-launch-sdk';
 
 const gdp = await getNetworkGDP([
   'agent1qWriter...',
@@ -588,7 +588,7 @@ Read and write agent storage data via the Agentverse hosting API. Storage is key
 List all storage keys for an agent.
 
 ```typescript
-import { listStorage } from 'agentlaunch-sdk';
+import { listStorage } from '@fetchai/agent-launch-sdk';
 
 const entries = await listStorage('agent1q...');
 for (const entry of entries) {
@@ -601,7 +601,7 @@ for (const entry of entries) {
 Get a single storage value. Returns `null` if the key doesn't exist.
 
 ```typescript
-import { getStorage } from 'agentlaunch-sdk';
+import { getStorage } from '@fetchai/agent-launch-sdk';
 
 const value = await getStorage('agent1q...', 'revenue_summary');
 if (value) {
@@ -615,7 +615,7 @@ if (value) {
 Set a storage value. Creates or overwrites.
 
 ```typescript
-import { putStorage } from 'agentlaunch-sdk';
+import { putStorage } from '@fetchai/agent-launch-sdk';
 
 await putStorage('agent1q...', 'config', JSON.stringify({ mode: 'boost' }));
 ```
@@ -625,7 +625,7 @@ await putStorage('agent1q...', 'config', JSON.stringify({ mode: 'boost' }));
 Delete a storage key. No-op if the key doesn't exist.
 
 ```typescript
-import { deleteStorage } from 'agentlaunch-sdk';
+import { deleteStorage } from '@fetchai/agent-launch-sdk';
 
 await deleteStorage('agent1q...', 'old_config');
 ```
@@ -639,7 +639,7 @@ await deleteStorage('agent1q...', 'old_config');
 Get the current bonding-curve price of a token in FET.
 
 ```typescript
-import { getTokenPrice } from 'agentlaunch-sdk';
+import { getTokenPrice } from '@fetchai/agent-launch-sdk';
 
 const price = await getTokenPrice('0xAbCd...');
 console.log(`Current price: ${price} FET`);
@@ -650,7 +650,7 @@ console.log(`Current price: ${price} FET`);
 Simulate a buy and return the estimated token yield, price impact, and fee breakdown.
 
 ```typescript
-import { calculateBuy } from 'agentlaunch-sdk';
+import { calculateBuy } from '@fetchai/agent-launch-sdk';
 
 const result = await calculateBuy('0xAbCd...', '100');
 console.log(`Tokens received: ${result.tokensReceived}`);
@@ -664,7 +664,7 @@ console.log(`Protocol fee:    ${result.fee} FET`); // 2%, 100% to treasury
 Simulate a sell and return the estimated FET proceeds.
 
 ```typescript
-import { calculateSell } from 'agentlaunch-sdk';
+import { calculateSell } from '@fetchai/agent-launch-sdk';
 
 const result = await calculateSell('0xAbCd...', '500000');
 console.log(`FET received:  ${result.fetReceived}`);
@@ -677,7 +677,7 @@ console.log(`Protocol fee:  ${result.fee} FET`); // 2%, 100% to treasury
 Fetch aggregated platform-level statistics.
 
 ```typescript
-import { getPlatformStats } from 'agentlaunch-sdk';
+import { getPlatformStats } from '@fetchai/agent-launch-sdk';
 
 const stats = await getPlatformStats();
 console.log(`Total tokens:  ${stats.totalTokens}`);
@@ -690,7 +690,7 @@ console.log(`On bonding:    ${stats.totalBonding}`);
 Get the holder list for a token, or look up a specific wallet.
 
 ```typescript
-import { getTokenHolders } from 'agentlaunch-sdk';
+import { getTokenHolders } from '@fetchai/agent-launch-sdk';
 
 // Full holder list
 const { holders, total } = await getTokenHolders('0xAbCd...');
@@ -708,7 +708,7 @@ const holder = await getTokenHolders('0xAbCd...', '0xUserWallet...');
 Fetch all comments on a token's page. No authentication required.
 
 ```typescript
-import { getComments } from 'agentlaunch-sdk';
+import { getComments } from '@fetchai/agent-launch-sdk';
 
 const comments = await getComments('0xAbCd...');
 for (const c of comments) {
@@ -721,7 +721,7 @@ for (const c of comments) {
 Post a comment on a token page. Requires API key.
 
 ```typescript
-import { postComment } from 'agentlaunch-sdk';
+import { postComment } from '@fetchai/agent-launch-sdk';
 
 const result = await postComment({
   tokenAddress: '0xAbCd...',
@@ -739,7 +739,7 @@ Token deployment uses handoff links (irreversible, 120 FET). For autonomous trad
 #### `generateDeployLink(tokenId, baseUrl?)`
 
 ```typescript
-import { generateDeployLink } from 'agentlaunch-sdk';
+import { generateDeployLink } from '@fetchai/agent-launch-sdk';
 
 const link = generateDeployLink(42);
 // https://agent-launch.ai/deploy/42
@@ -748,7 +748,7 @@ const link = generateDeployLink(42);
 #### `generateTradeLink(address, opts?, baseUrl?)`
 
 ```typescript
-import { generateTradeLink } from 'agentlaunch-sdk';
+import { generateTradeLink } from '@fetchai/agent-launch-sdk';
 
 generateTradeLink('0xAbCd...');
 // https://agent-launch.ai/trade/0xAbCd...
@@ -760,7 +760,7 @@ generateTradeLink('0xAbCd...', { action: 'buy', amount: 100 });
 #### `generateBuyLink(address, amount?, baseUrl?)` / `generateSellLink(address, amount?, baseUrl?)`
 
 ```typescript
-import { generateBuyLink, generateSellLink } from 'agentlaunch-sdk';
+import { generateBuyLink, generateSellLink } from '@fetchai/agent-launch-sdk';
 
 const buyLink = generateBuyLink('0xAbCd...', 100);
 const sellLink = generateSellLink('0xAbCd...', 500);
@@ -769,7 +769,7 @@ const sellLink = generateSellLink('0xAbCd...', 500);
 #### `generateDelegationLink(tokenAddress, spenderAddress, amount, baseUrl?)`
 
 ```typescript
-import { generateDelegationLink } from 'agentlaunch-sdk';
+import { generateDelegationLink } from '@fetchai/agent-launch-sdk';
 
 const link = generateDelegationLink('0xFET...', '0xAgent...', '100');
 // https://agent-launch.ai/delegate?token=0xFET...&spender=0xAgent...&amount=100
@@ -780,7 +780,7 @@ const link = generateDelegationLink('0xFET...', '0xAgent...', '100');
 Generate a fiat onramp link (MoonPay or Transak). Handoff-only — never processes fiat directly.
 
 ```typescript
-import { generateFiatOnrampLink } from 'agentlaunch-sdk';
+import { generateFiatOnrampLink } from '@fetchai/agent-launch-sdk';
 
 const { provider, url } = generateFiatOnrampLink({
   fiatAmount: '50',
@@ -800,7 +800,7 @@ const { provider, url } = generateFiatOnrampLink({
 Exchange an Agentverse API key for a platform JWT.
 
 ```typescript
-import { authenticate } from 'agentlaunch-sdk';
+import { authenticate } from '@fetchai/agent-launch-sdk';
 
 const { data } = await authenticate('av-xxxxxxxxxxxxxxxx');
 console.log(data.token);      // JWT string
@@ -812,7 +812,7 @@ console.log(data.expires_in); // seconds until expiry
 List the Agentverse agents owned by the caller's API key.
 
 ```typescript
-import { getMyAgents } from 'agentlaunch-sdk';
+import { getMyAgents } from '@fetchai/agent-launch-sdk';
 
 const { data } = await getMyAgents();
 console.log(data.agents.map(a => a.address));
@@ -823,7 +823,7 @@ console.log(data.agents.map(a => a.address));
 Fetch all agents belonging to an Agentverse API key.
 
 ```typescript
-import { importFromAgentverse } from 'agentlaunch-sdk';
+import { importFromAgentverse } from '@fetchai/agent-launch-sdk';
 
 const { agents, count } = await importFromAgentverse('av-xxxxxxxxxxxxxxxx');
 ```
@@ -837,7 +837,7 @@ const { agents, count } = await importFromAgentverse('av-xxxxxxxxxxxxxxxx');
 Deploy an agent to Agentverse in a single call.
 
 ```typescript
-import { deployAgent } from 'agentlaunch-sdk';
+import { deployAgent } from '@fetchai/agent-launch-sdk';
 
 const result = await deployAgent({
   apiKey: 'av-xxxxxxxxxxxxxxxx',
@@ -858,7 +858,7 @@ console.log(result.optimization);  // 7-item checklist
 Update metadata on an existing Agentverse agent to improve ranking.
 
 ```typescript
-import { updateAgent } from 'agentlaunch-sdk';
+import { updateAgent } from '@fetchai/agent-launch-sdk';
 
 const result = await updateAgent({
   apiKey: 'av-xxxxxxxxxxxxxxxx',
@@ -879,7 +879,7 @@ console.log(result.optimization);   // 7-item checklist
 Build a 7-item checklist for an agent's Agentverse ranking factors.
 
 ```typescript
-import { buildOptimizationChecklist } from 'agentlaunch-sdk';
+import { buildOptimizationChecklist } from '@fetchai/agent-launch-sdk';
 
 const checklist = buildOptimizationChecklist({
   agentAddress: 'agent1q...',
@@ -898,7 +898,7 @@ const checklist = buildOptimizationChecklist({
 For a more ergonomic interface, use the `AgentLaunch` class with 8 namespaces:
 
 ```typescript
-import { AgentLaunch } from 'agentlaunch-sdk';
+import { AgentLaunch } from '@fetchai/agent-launch-sdk';
 
 const al = new AgentLaunch({ apiKey: 'av-xxxxxxxxxxxxxxxx' });
 
@@ -961,7 +961,7 @@ const gdp = await al.commerce.getNetworkGDP(['agent1q...', 'agent1q...']);
 The underlying HTTP client. Use directly for advanced scenarios.
 
 ```typescript
-import { AgentLaunchClient } from 'agentlaunch-sdk';
+import { AgentLaunchClient } from '@fetchai/agent-launch-sdk';
 
 const client = new AgentLaunchClient({
   apiKey: process.env.AGENTVERSE_API_KEY,
@@ -983,7 +983,7 @@ const result = await client.post<MyType>('/tokenize', body);
 All SDK methods throw `AgentLaunchError` on non-2xx responses.
 
 ```typescript
-import { tokenize, AgentLaunchError } from 'agentlaunch-sdk';
+import { tokenize, AgentLaunchError } from '@fetchai/agent-launch-sdk';
 
 try {
   const { data } = await tokenize({ agentAddress: 'agent1q...' });
@@ -1024,7 +1024,7 @@ On-chain functions throw standard `Error` with descriptive messages:
 ## Cross-References
 
 - **CLI equivalent:** [`agentlaunch`](../cli/README.md) — wraps this SDK with interactive prompts
-- **MCP tools:** [`agent-launch-mcp`](../mcp/README.md) — wraps this SDK as Claude Code tools
+- **MCP tools:** [`@fetchai/agent-launch-mcp`](../mcp/README.md) — wraps this SDK as Claude Code tools
 - **Templates:** [`agentlaunch-templates`](../templates/README.md) — agent code generation
 
 ## License


### PR DESCRIPTION
## Summary

Updates all documentation to reflect the correct `@fetchai` scoped package names and fixes incorrect `npx` invocations.

## Changes

### Package name corrections (unscoped → scoped)
- `agentlaunch-sdk` → `@fetchai/agent-launch-sdk`
- `agent-launch-mcp` → `@fetchai/agent-launch-mcp`
- `agentlaunch` (npm install) → `@fetchai/agent-launch-cli`

### npx command fixes
- `npx agentlaunch` does not work with the scoped CLI package; corrected to `npx @fetchai/agent-launch-cli` where one-off usage is shown, or replaced with the `agentlaunch` binary name (after global install) elsewhere
- `npx agent-launch-mcp` → `npx @fetchai/agent-launch-mcp`

### Files changed
- `packages/sdk/README.md` — title, badge, install command, all 54 import examples, MCP cross-ref
- `packages/cli/README.md` — install section, Commands section npx examples, workflow example, JSON mode example, cross-refs
- `packages/mcp/README.md` — version (2.3.3→3.0.0), npm link, npx commands, Claude Code/Desktop config args, SDK cross-ref, npm package link
- `README.md` — top-level quick start, MCP example, SDK import, CLI Commands block (added install comment, converted npx→binary)
- `TUTORIAL.md` — added CLI install to Prerequisites, converted all `npx agentlaunch` → `agentlaunch`, fixed SDK import

## Testing
All links and command examples verified against published npm packages:
- `@fetchai/agent-launch-sdk@0.3.0`
- `@fetchai/agent-launch-cli@2.0.0`
- `@fetchai/agent-launch-mcp@3.0.0`
- `@fetchai/agent-launch-templates@1.0.0`