### PR TITLE
fix(sdk): wrap balanceOf in safeBalanceOf to handle BAD_DATA — Issue #490

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `agentlaunch-sdk` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-04-24
+
+### Fixed
+
+- **`getWalletBalances` BAD_DATA crash (Issue #490)** — `balanceOf()` calls on a
+  non-ERC-20 address (or any contract that returns an empty `0x` response) no
+  longer crash the function. A new `safeBalanceOf` internal helper wraps every
+  `contract.balanceOf()` call and returns `0n` on `BAD_DATA`, `CALL_EXCEPTION`,
+  or `INVALID_ARGUMENT` errors from ethers v6, while still re-throwing
+  unexpected network errors.
+
+---
+
 ## [0.2.15] - 2026-04-03
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fetchai/agent-launch-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TypeScript SDK for the AgentLaunch platform — create AI agent tokens, query market data, and generate handoff links",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/src/onchain.ts
+++ b/packages/sdk/src/onchain.ts
@@ -188,6 +188,40 @@ function resolveChain(config?: OnchainConfig): ChainConfig {
   return chain;
 }
 
+/**
+ * Safe wrapper around `contract.balanceOf(address)` that returns `0n` on any
+ * RPC failure, including the `BAD_DATA` / empty-`0x` response thrown by
+ * ethers v6 when the target address is not a real ERC-20 contract.
+ *
+ * @param contract - ethers Contract instance with a `balanceOf` method
+ * @param address  - Wallet address to query
+ * @returns Token balance, or `0n` if the call reverts / returns bad data
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function safeBalanceOf(contract: any, address: string): Promise<bigint> {
+  try {
+    const balance = await contract.balanceOf(address);
+    return balance;
+  } catch (err: unknown) {
+    // ethers v6 throws with code "BAD_DATA" when the response is "0x" (empty)
+    // which happens when calling balanceOf on a non-ERC-20 address.
+    // Any other RPC error (CALL_EXCEPTION, network issues) should also return 0
+    // rather than crashing the entire getWalletBalances call.
+    const code = (err as { code?: string })?.code;
+    const value = (err as { value?: string })?.value;
+    if (
+      code === 'BAD_DATA' ||
+      code === 'CALL_EXCEPTION' ||
+      code === 'INVALID_ARGUMENT' ||
+      value === '0x'
+    ) {
+      return 0n;
+    }
+    // Re-throw unexpected errors so they're not silently swallowed.
+    throw err;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // buyTokens
 // ---------------------------------------------------------------------------
@@ -398,11 +432,13 @@ export async function getWalletBalances(
 
   const fetContract = new ethers.Contract(fetAddress, ERC20_ABI, provider);
 
-  // Parallel balance queries
+  // Parallel balance queries — use safeBalanceOf so a non-ERC-20 address
+  // (or any contract returning empty "0x" data) returns 0n instead of
+  // throwing BAD_DATA and crashing the entire call (Issue #490).
   const [bnbBalance, fetBalance, tokenBalance] = await Promise.all([
     provider.getBalance(wallet.address),
-    fetContract.balanceOf(wallet.address),
-    tokenContract.balanceOf(wallet.address),
+    safeBalanceOf(fetContract, wallet.address),
+    safeBalanceOf(tokenContract, wallet.address),
   ]);
 
   return {


### PR DESCRIPTION
## Problem

`getWalletBalances()` crashed with a `BAD_DATA` error when called with a non-ERC-20 address (e.g. a plain wallet address, an EOA, or any contract that does not implement `balanceOf`). ethers v6 throws `BAD_DATA` when it receives an empty `0x` response and cannot ABI-decode it as `uint256`.

## Root Cause

```typescript
// Both of these could throw BAD_DATA / CALL_EXCEPTION:
fetContract.balanceOf(wallet.address)
tokenContract.balanceOf(wallet.address)
```

## Fix

Added a `safeBalanceOf(contract, address)` internal helper that:
- Returns `0n` for `BAD_DATA`, `CALL_EXCEPTION`, and `INVALID_ARGUMENT` errors (all originating from bad/empty RPC response data)
- Re-throws any other (unexpected) error so genuine issues are not silently swallowed

Both `fetContract.balanceOf()` and `tokenContract.balanceOf()` in `getWalletBalances()` are now wrapped with this helper.

## Changes

- `packages/sdk/src/onchain.ts` — add `safeBalanceOf` helper, update `getWalletBalances`
- `packages/sdk/package.json` — version `0.3.1` → `0.3.2`
- `packages/sdk/CHANGELOG.md` — document the fix

## Publishing

`@fetchai/agent-launch-sdk@0.3.2` has already been published to npm.

Closes #490